### PR TITLE
chore: add Clerk setup

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key
+CLERK_SECRET_KEY=sk_test_your_secret_key

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Clerk Setup
+
+This project integrates [Clerk](https://clerk.com) for authentication.
+To run the application locally, you'll need API keys from the Clerk dashboard:
+
+1. Sign in to the Clerk dashboard and create an application.
+2. Copy the **Publishable Key** and **Secret Key**.
+3. Create a `.env.local` file in the project root and add:
+
+   ```bash
+   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_your_publishable_key
+   CLERK_SECRET_KEY=sk_test_your_secret_key
+   ```
+
+These values enable Clerk in development. Never commit real keys to version control.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@clerk/nextjs": "^4.32.0",
+    "@clerk/types": "^3.1.0",
     "@prisma/client": "^6.16.1",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.57.4",


### PR DESCRIPTION
## Summary
- add Clerk dependencies for Next.js integration
- document Clerk environment setup
- include `.env.local` with publishable and secret key placeholders

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@clerk%2fnextjs)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3e695a03c83208fba336a8d24e83d