### PR TITLE
feat: add clerk auth middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,17 @@
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+]);
+
+export default clerkMiddleware((auth, req) => {
+  if (!isPublicRoute(req)) {
+    auth().protect();
+  }
+});
+
+export const config = {
+  matcher: ["/((?!.*\\..*|_next|sign-in|sign-up|$).*)"],
+};


### PR DESCRIPTION
## Summary
- secure routes with Clerk middleware
- skip public pages with matcher configuration

## Testing
- `bun run lint` *(fails: command produced no output in this environment)*
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e69aab008320b5145037c882f44b