### PR TITLE
Add protected dashboard using Clerk auth

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,11 @@
+import { currentUser } from "@clerk/nextjs/server";
+
+export default async function DashboardPage() {
+  const user = await currentUser();
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl">Hello, {user?.firstName ?? "User"}!</h1>
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,7 @@
+import { authMiddleware } from "@clerk/nextjs";
+
+export default authMiddleware();
+
+export const config = {
+  matcher: ["/dashboard(.*)"],
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "15.5.3",
     "prisma": "^6.16.1",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "@clerk/nextjs": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add `@clerk/nextjs` dependency for user authentication
- create dashboard page that greets the signed-in user
- protect `/dashboard` with Clerk middleware

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: 2131 problems (445 errors, 1686 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c3e69bb0d4832091ed0363b22a1d7e