### PR TITLE
Skip Clerk auth for server actions

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,6 +8,7 @@ const isPublicRoute = createRouteMatcher([
 
 export default clerkMiddleware((auth, req) => {
   if (!isPublicRoute(req)) {
+    if (req.method === "POST" && req.headers.has("Next-Action")) return;
     auth().protect();
   }
 });


### PR DESCRIPTION
## Summary
- Skip auth in middleware for POST requests marked as server actions
- Preserve existing route matcher excluding static and auth routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3f1d956588320ab5d542b31713aa5