### PR TITLE
Fix Clerk middleware protect usage

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,10 +6,10 @@ const isPublicRoute = createRouteMatcher([
   "/sign-up(.*)",
 ]);
 
-export default clerkMiddleware((auth, req) => {
+export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {
     if (req.method === "POST" && req.headers.has("Next-Action")) return;
-    auth().protect();
+    await auth.protect();
   }
 });
 


### PR DESCRIPTION
## Summary
- call Clerk middleware with async callback
- await `auth.protect()` instead of `auth().protect()`

## Testing
- `npm run lint` (fails: A `require()` style import is forbidden)
- `npm run build` (fails: Failed to fetch `Geist` from Google Fonts)
- `node test-middleware.js`

------
https://chatgpt.com/codex/tasks/task_e_68c59c36b14083208646a748abc79774