### PR TITLE
fix: use generated Prisma client

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
+      "lib/generated/**",
     ],
   },
 ];

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,5 +1,6 @@
 // lib/prisma.ts
-import { PrismaClient } from '@prisma/client'
+// Use the generated Prisma client located in lib/generated/prisma
+import { PrismaClient } from './generated/prisma'
 const globalForPrisma = global as unknown as { prisma: PrismaClient }
 export const prisma = globalForPrisma.prisma ?? new PrismaClient()
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
## Summary
- import Prisma client from generated output
- ignore generated files in ESLint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5a396ec348320abd1189004435b99