### PR TITLE
Improve Sidebar navigation fetching resilience

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,6 +1,5 @@
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import PageHeader from "@/components/layout/PageHeader";
-import SidebarLayout from "@/components/layout/SidebarLayout";
 import { RedirectToSignIn, SignedIn, SignedOut } from "@clerk/nextjs";
 
 const items = [{ name: "Home", href: "/home" }];

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -130,19 +130,62 @@ export default function Sidebar() {
     const [navigation, setNavigation] = useState<NavigationItem[]>([]);
 
     useEffect(() => {
-        fetch("/api/navigation")
-            .then((res) => res.json())
-            .then((data: NavigationApiItem[]) => {
-                data.sort((a, b) => a.order - b.order);
+        const fetchNavigation = async () => {
+            try {
+                const response = await fetch("/api/navigation");
+
+                if (!response.ok) {
+                    console.error(
+                        "Failed to fetch navigation:",
+                        response.status,
+                        response.statusText
+                    );
+                    setNavigation([]);
+                    return;
+                }
+
+                const body = await response.text();
+
+                if (!body) {
+                    setNavigation([]);
+                    return;
+                }
+
+                let parsed: unknown;
+
+                try {
+                    parsed = JSON.parse(body);
+                } catch (error) {
+                    console.error("Failed to parse navigation response:", error);
+                    setNavigation([]);
+                    return;
+                }
+
+                if (!Array.isArray(parsed)) {
+                    console.error("Navigation response is not an array");
+                    setNavigation([]);
+                    return;
+                }
+
+                const data = parsed as NavigationApiItem[];
+
+                const sorted = [...data].sort((a, b) => a.order - b.order);
+
                 setNavigation(
-                    data.map((item) => ({
+                    sorted.map((item) => ({
                         name: item.navigationName,
                         href: item.href,
                         icon: item.icon,
                         current: item.current,
                     }))
                 );
-            });
+            } catch (error) {
+                console.error("Error fetching navigation:", error);
+                setNavigation([]);
+            }
+        };
+
+        fetchNavigation();
     }, []);
 
     return (


### PR DESCRIPTION
## Summary
- wrap the Sidebar navigation fetch in async/await with robust error handling
- default navigation state to an empty array when the response is empty or malformed
- remove an unused SidebarLayout import from the home page to satisfy lint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b897ce448320a3fc8af69c6b7bc8