### PR TITLE
Allow public access to navigation API

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,7 @@ const isPublicRoute = createRouteMatcher([
   "/",
   "/sign-in(.*)",
   "/sign-up(.*)",
+  "/api/navigation",
 ]);
 
 export default clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
## Summary
- allow the navigation API route to bypass authentication so the sidebar fetch succeeds without errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b899644c8320ad901bfac4475903