### PR TITLE
Align navigation sort order property

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,6 +1,5 @@
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import PageHeader from "@/components/layout/PageHeader";
-import SidebarLayout from "@/components/layout/SidebarLayout";
 import { RedirectToSignIn, SignedIn, SignedOut } from "@clerk/nextjs";
 
 const items = [{ name: "Home", href: "/home" }];

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -94,7 +94,7 @@ interface NavigationApiItem {
     href: string;
     icon: keyof typeof iconMap;
     current: boolean;
-    order: number;
+    sortOrder: number;
 }
 
 const teams = [
@@ -133,7 +133,7 @@ export default function Sidebar() {
         fetch("/api/navigation")
             .then((res) => res.json())
             .then((data: NavigationApiItem[]) => {
-                data.sort((a, b) => a.order - b.order);
+                data.sort((a, b) => a.sortOrder - b.sortOrder);
                 setNavigation(
                     data.map((item) => ({
                         name: item.navigationName,


### PR DESCRIPTION
## Summary
- standardize the navigation API item contract to use `sortOrder` consistently when sorting
- remove an unused `SidebarLayout` import from the home page to keep lint clean

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b89a35988320b869098fd6f58584