### PR TITLE
Rename navigation order property

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -94,7 +94,7 @@ interface NavigationApiItem {
     href: string;
     icon: keyof typeof iconMap;
     current: boolean;
-    order: number;
+    sortOrder: number;
 }
 
 const teams = [
@@ -169,7 +169,7 @@ export default function Sidebar() {
 
                 const data = parsed as NavigationApiItem[];
 
-                const sorted = [...data].sort((a, b) => a.order - b.order);
+                const sorted = [...data].sort((a, b) => a.sortOrder - b.sortOrder);
 
                 setNavigation(
                     sorted.map((item) => ({


### PR DESCRIPTION
## Summary
- rename the navigation API item field from `order` to `sortOrder`
- update the sidebar sorting to use the new `sortOrder` field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8cb2caab8832093b3f5ed8a7b5bc0