### PR TITLE
Refactor layout auth handling

### DIFF
--- a/app/api/diag/route.ts
+++ b/app/api/diag/route.ts
@@ -3,10 +3,25 @@ import { NextResponse } from 'next/server'
 import dns from 'node:dns/promises'
 import { PrismaClient } from '@prisma/client'
 
+type DiagnosticInfo = {
+  nodeVersion?: string
+  runtime?: string
+  hasDatabaseUrl?: boolean
+  hasDirectUrl?: boolean
+  dbHost?: string
+  dnsLookup?: Awaited<ReturnType<typeof dns.lookup>>
+  prismaOk?: boolean
+  dbNow?: unknown
+  errorName?: string
+  errorMessage?: string
+  errorCode?: unknown
+  errorMeta?: unknown
+}
+
 export const dynamic = 'force-dynamic' // disable caching
 
 export async function GET() {
-  const info: any = {}
+  const info: DiagnosticInfo = {}
 
   try {
     info.nodeVersion = process.version
@@ -36,12 +51,23 @@ export async function GET() {
     await prisma.$disconnect()
 
     return NextResponse.json(info, { status: 200 })
-  } catch (e: any) {
+  } catch (error: unknown) {
     info.prismaOk = false
-    info.errorName = e?.name
-    info.errorMessage = e?.message
-    info.errorCode = e?.code
-    info.errorMeta = e?.meta
+
+    if (typeof error === 'object' && error !== null) {
+      const { name, message } = error as { name?: string; message?: string }
+      info.errorName = name
+      info.errorMessage = message
+
+      if ('code' in error) {
+        info.errorCode = (error as { code?: unknown }).code
+      }
+
+      if ('meta' in error) {
+        info.errorMeta = (error as { meta?: unknown }).meta
+      }
+    }
+
     return NextResponse.json(info, { status: 500 })
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,5 @@
-"use client";
-
-import {
-    ClerkProvider,
-    SignedIn,
-    SignedOut,
-    SignInButton,
-    SignUpButton,
-} from "@clerk/nextjs";
+import { ClerkProvider, SignInButton, SignUpButton } from "@clerk/nextjs";
+import { auth } from "@clerk/nextjs/server";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -22,34 +15,37 @@ const geistMono = Geist_Mono({
     subsets: ["latin"],
 });
 
-export default function RootLayout({
+export default async function RootLayout({
     children,
 }: Readonly<{
     children: React.ReactNode;
 }>) {
+    const authState = await auth();
+    const { userId } = authState;
+
     return (
-        <ClerkProvider>
+        <ClerkProvider initialState={authState}>
             <html lang="en">
                 <body
                     className={`${geistSans.variable} ${geistMono.variable} antialiased`}
                 >
-                    <SignedOut>
-                        <header className="flex justify-end items-center p-4 gap-4 h-16">
-                            <SignInButton />
-                            <SignUpButton>
-                                <button className="bg-[#6c47ff] text-white rounded-full font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 cursor-pointer">
-                                    Sign Up
-                                </button>
-                            </SignUpButton>
-                        </header>
-                        <main>{children}</main>
-                    </SignedOut>
-
-                    <SignedIn>
+                    {userId ? (
                         <SidebarLayout>
                             <main>{children}</main>
                         </SidebarLayout>
-                    </SignedIn>
+                    ) : (
+                        <>
+                            <header className="flex justify-end items-center p-4 gap-4 h-16">
+                                <SignInButton />
+                                <SignUpButton>
+                                    <button className="bg-[#6c47ff] text-white rounded-full font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 cursor-pointer">
+                                        Sign Up
+                                    </button>
+                                </SignUpButton>
+                            </header>
+                            <main>{children}</main>
+                        </>
+                    )}
                 </body>
             </html>
         </ClerkProvider>


### PR DESCRIPTION
## Summary
- convert the app layout to a server component and drive the rendered tree from Clerk auth state
- pass Clerk initial state from the server auth call while keeping provider wrapping
- tighten diagnostic route typing to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb7d013534832097b43c81c2882ea6