### PR TITLE
Enable dynamic Clerk rendering

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({
     const { userId } = authState;
 
     return (
-        <ClerkProvider>
+        <ClerkProvider dynamic>
             <html lang="en">
                 <body
                     className={`${geistSans.variable} ${geistMono.variable} antialiased`}


### PR DESCRIPTION
## Summary
- opt the root ClerkProvider into dynamic rendering to resolve hydration mismatches for auth-aware UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb8f70913c8320b86eb188e9da991f