### PR TITLE
Fix server action header detection in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,7 +9,12 @@ const isPublicRoute = createRouteMatcher([
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {
-    if (req.method === "POST" && req.headers.has("Next-Action")) return;
+    if (
+      req.method === "POST" &&
+      (req.headers.get("next-action") ?? req.headers.get("Next-Action"))
+    ) {
+      return;
+    }
     await auth.protect();
   }
 });


### PR DESCRIPTION
## Summary
- adjust middleware server action detection to read the lowercase `next-action` header used by Next.js and keep a fallback to `Next-Action`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb91c99d548320a1d0cad50585cee9