### PR TITLE
Refactor sidebar navigation data flow

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -47,7 +47,6 @@ import {
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import React, { useEffect, useState } from "react";
 
 const iconMap = {
     AcademicCapIcon,
@@ -94,19 +93,11 @@ const iconMap = {
     WrenchScrewdriverIcon,
 };
 
-interface NavigationItem {
+export interface NavigationItem {
     name: string;
     href: string;
     icon: keyof typeof iconMap;
     current: boolean;
-}
-
-interface NavigationApiItem {
-    navigationName: string;
-    href: string;
-    icon: keyof typeof iconMap;
-    current: boolean;
-    sortOrder: number;
 }
 
 const teams = [
@@ -137,73 +128,12 @@ function classNames(...classes: (string | undefined | null | false)[]) {
     return classes.filter(Boolean).join(" ");
 }
 
-export default function Sidebar() {
+interface SidebarProps {
+    navigation: NavigationItem[];
+}
+
+export default function Sidebar({ navigation }: SidebarProps) {
     const pathname = usePathname();
-    const [navigation, setNavigation] = useState<NavigationItem[]>([]);
-
-    useEffect(() => {
-        const fetchNavigation = async () => {
-            try {
-                const response = await fetch("/api/navigation");
-
-                if (!response.ok) {
-                    console.error(
-                        "Failed to fetch navigation:",
-                        response.status,
-                        response.statusText
-                    );
-                    setNavigation([]);
-                    return;
-                }
-
-                const body = await response.text();
-
-                if (!body) {
-                    setNavigation([]);
-                    return;
-                }
-
-                let parsed: unknown;
-
-                try {
-                    parsed = JSON.parse(body);
-                } catch (error) {
-                    console.error(
-                        "Failed to parse navigation response:",
-                        error
-                    );
-                    setNavigation([]);
-                    return;
-                }
-
-                if (!Array.isArray(parsed)) {
-                    console.error("Navigation response is not an array");
-                    setNavigation([]);
-                    return;
-                }
-
-                const data = parsed as NavigationApiItem[];
-
-                const sorted = [...data].sort(
-                    (a, b) => a.sortOrder - b.sortOrder
-                );
-
-                setNavigation(
-                    sorted.map((item) => ({
-                        name: item.navigationName,
-                        href: item.href,
-                        icon: item.icon,
-                        current: item.current,
-                    }))
-                );
-            } catch (error) {
-                console.error("Error fetching navigation:", error);
-                setNavigation([]);
-            }
-        };
-
-        fetchNavigation();
-    }, []);
 
     return (
         <>

--- a/components/layout/SidebarLayout.tsx
+++ b/components/layout/SidebarLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import Sidebar from "./Sidebar";
+import { useEffect, useState } from "react";
+import Sidebar, { type NavigationItem } from "./Sidebar";
 import SidebarDrawer from "./SidebarDrawer";
 import Topbar from "./Topbar";
 import { SignedIn } from "@clerk/nextjs";
@@ -12,21 +12,94 @@ export default function SidebarLayout({
     children: React.ReactNode;
 }) {
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+    const [navigation, setNavigation] = useState<NavigationItem[]>([]);
 
     const openDrawer = () => setIsDrawerOpen(true);
     const closeDrawer = () => setIsDrawerOpen(false);
+
+    useEffect(() => {
+        interface NavigationApiItem {
+            navigationName: string;
+            href: string;
+            icon: NavigationItem["icon"];
+            current: boolean;
+            sortOrder: number;
+        }
+
+        const fetchNavigation = async () => {
+            try {
+                const response = await fetch("/api/navigation");
+
+                if (!response.ok) {
+                    console.error(
+                        "Failed to fetch navigation:",
+                        response.status,
+                        response.statusText
+                    );
+                    setNavigation([]);
+                    return;
+                }
+
+                const body = await response.text();
+
+                if (!body) {
+                    setNavigation([]);
+                    return;
+                }
+
+                let parsed: unknown;
+
+                try {
+                    parsed = JSON.parse(body);
+                } catch (error) {
+                    console.error(
+                        "Failed to parse navigation response:",
+                        error
+                    );
+                    setNavigation([]);
+                    return;
+                }
+
+                if (!Array.isArray(parsed)) {
+                    console.error("Navigation response is not an array");
+                    setNavigation([]);
+                    return;
+                }
+
+                const data = parsed as NavigationApiItem[];
+
+                const sorted = [...data].sort(
+                    (a, b) => a.sortOrder - b.sortOrder
+                );
+
+                setNavigation(
+                    sorted.map((item) => ({
+                        name: item.navigationName,
+                        href: item.href,
+                        icon: item.icon,
+                        current: item.current,
+                    }))
+                );
+            } catch (error) {
+                console.error("Error fetching navigation:", error);
+                setNavigation([]);
+            }
+        };
+
+        fetchNavigation();
+    }, []);
 
     return (
         <div className="min-h-screen flex bg-white text-black">
             <SignedIn>
                 {/* Static Sidebar for Desktop */}
                 <div className="hidden md:block w-64 border-r bg-gray-100">
-                    <Sidebar />
+                    <Sidebar navigation={navigation} />
                 </div>
 
                 {/* Dialog Sidebar for Mobile */}
                 <SidebarDrawer isOpen={isDrawerOpen} onClose={closeDrawer}>
-                    <Sidebar />
+                    <Sidebar navigation={navigation} />
                 </SidebarDrawer>
             </SignedIn>
 


### PR DESCRIPTION
## Summary
- export the `NavigationItem` type from the sidebar component and switch it to render a supplied navigation array
- load and sort navigation data inside `SidebarLayout` so both desktop and drawer sidebars reuse the same state
- pass the fetched navigation list to each `<Sidebar />` usage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc94004ad88320a98beec2969c64f0