### PR TITLE
Add role-based filtering to navigation API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # production
 /build
+dist-tests
 
 # misc
 .DS_Store

--- a/app/api/navigation/navigation-handler.ts
+++ b/app/api/navigation/navigation-handler.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export type NavigationHandlerDependencies = {
+    prisma: {
+        navigation: {
+            findMany: (...args: unknown[]) => Promise<unknown>;
+        };
+        user: {
+            findFirst: (...args: unknown[]) => Promise<{ roleId: number } | null>;
+        };
+    };
+    auth: () => Promise<{ userId: string | null } | null>;
+};
+
+const navigationSelect = {
+    navigationName: true,
+    href: true,
+    icon: true,
+    current: true,
+    sortOrder: true,
+} as const;
+
+function parseRoleIdFromRequest(request: Request | NextRequest) {
+    const roleIdParam = new URL(request.url).searchParams.get("roleId");
+    if (roleIdParam === null) {
+        return { parsedRoleId: undefined } as const;
+    }
+
+    const trimmed = roleIdParam.trim();
+    const parsedRoleId = Number.parseInt(trimmed, 10);
+
+    if (!Number.isInteger(parsedRoleId) || parsedRoleId <= 0) {
+        return {
+            error: "roleId must be a positive integer",
+        } as const;
+    }
+
+    return { parsedRoleId } as const;
+}
+
+export function createNavigationHandler({ prisma: prismaClient, auth: authFn }: NavigationHandlerDependencies) {
+    return async function GET(request: Request | NextRequest) {
+        try {
+            if (!process.env.DATABASE_URL) {
+                throw new Error("Missing environment variables: DATABASE_URL");
+            }
+
+            const { parsedRoleId, error } = parseRoleIdFromRequest(request);
+            if (error) {
+                return NextResponse.json({ error }, { status: 400 });
+            }
+
+            if (typeof parsedRoleId === "number") {
+                const navigation = await prismaClient.navigation.findMany({
+                    where: { roleId: parsedRoleId },
+                    orderBy: { sortOrder: "asc" },
+                    select: navigationSelect,
+                });
+
+                return NextResponse.json(navigation);
+            }
+
+            if (!process.env.CLERK_SECRET_KEY) {
+                throw new Error("Missing environment variables: CLERK_SECRET_KEY");
+            }
+
+            const authResult = await authFn();
+            const userId = authResult?.userId ?? null;
+            if (!userId) {
+                return NextResponse.json([]);
+            }
+
+            const user = await prismaClient.user.findFirst({ where: { clerkId: userId } });
+            if (!user) {
+                return NextResponse.json([]);
+            }
+
+            const navigation = await prismaClient.navigation.findMany({
+                where: { roleId: user.roleId },
+                orderBy: { sortOrder: "asc" },
+                select: navigationSelect,
+            });
+
+            return NextResponse.json(navigation);
+        } catch (error) {
+            console.error("Navigation API error:", error);
+            const message = error instanceof Error ? error.message : "Failed to fetch navigation";
+            return NextResponse.json({ error: message }, { status: 500 });
+        }
+    };
+}

--- a/app/api/navigation/route.ts
+++ b/app/api/navigation/route.ts
@@ -1,48 +1,9 @@
-import { prisma } from "@/lib/prisma";
-import { NextResponse } from "next/server";
+import { prisma } from "../../../lib/prisma";
 import { auth } from "@clerk/nextjs/server";
 
-export async function GET() {
-    try {
-        const requiredEnvVars = {
-            CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
-            DATABASE_URL: process.env.DATABASE_URL,
-        };
+import { createNavigationHandler, type NavigationHandlerDependencies } from "./navigation-handler";
 
-        const missingEnvVars = Object.entries(requiredEnvVars)
-            .filter(([, value]) => !value)
-            .map(([key]) => key);
-
-        if (missingEnvVars.length > 0) {
-            throw new Error(`Missing environment variables: ${missingEnvVars.join(", ")}`);
-        }
-
-        const { userId } = await auth();
-        if (!userId) {
-            return NextResponse.json([]);
-        }
-
-        const user = await prisma.user.findFirst({ where: { clerkId: userId } });
-        if (!user) {
-            return NextResponse.json([]);
-        }
-
-        const navigation = await prisma.navigation.findMany({
-            where: { roleId: user.roleId },
-            orderBy: { sortOrder: "asc" },
-            select: {
-                navigationName: true,
-                href: true,
-                icon: true,
-                current: true,
-                sortOrder: true,
-            },
-        });
-
-        return NextResponse.json(navigation);
-    } catch (error) {
-        console.error("Navigation API error:", error);
-        const message = error instanceof Error ? error.message : "Failed to fetch navigation";
-        return NextResponse.json({ error: message }, { status: 500 });
-    }
-}
+export const GET = createNavigationHandler({
+    prisma: prisma as unknown as NavigationHandlerDependencies["prisma"],
+    auth: auth as NavigationHandlerDependencies["auth"],
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ const eslintConfig = [
       "build/**",
       "next-env.d.ts",
       "lib/generated/**",
+      "dist-tests/**",
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "npm run test:build && node --test dist-tests/tests/**/*.test.js",
+    "test:build": "rm -rf dist-tests && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.31.10",

--- a/tests/api/navigation.route.test.ts
+++ b/tests/api/navigation.route.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+
+import { createNavigationHandler } from "../../app/api/navigation/navigation-handler";
+
+test("returns 400 when roleId query parameter is invalid", async () => {
+    process.env.DATABASE_URL = "postgres://test";
+
+    const navigationFindMany = mock.fn(async () => []);
+    const prisma = {
+        navigation: { findMany: navigationFindMany },
+        user: { findFirst: mock.fn(async () => null) },
+    } as unknown as Parameters<typeof createNavigationHandler>[0]["prisma"];
+
+    const handler = createNavigationHandler({
+        prisma,
+        auth: async () => ({ userId: "user_123" }),
+    });
+
+    const response = await handler(new Request("https://example.com/api/navigation?roleId=abc"));
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: "roleId must be a positive integer" });
+    assert.equal(navigationFindMany.mock.callCount(), 0);
+});
+
+test("filters navigation by provided roleId", async () => {
+    process.env.DATABASE_URL = "postgres://test";
+
+    const expectedNavigation = [
+        {
+            navigationName: "Dashboard",
+            href: "/dashboard",
+            icon: "home",
+            current: false,
+            sortOrder: 1,
+        },
+    ];
+
+    const navigationFindMany = mock.fn(async () => expectedNavigation);
+    const prisma = {
+        navigation: { findMany: navigationFindMany },
+        user: {
+            findFirst: mock.fn(async () => {
+                throw new Error("user lookup should not run when roleId is provided");
+            }),
+        },
+    } as unknown as Parameters<typeof createNavigationHandler>[0]["prisma"];
+
+    const handler = createNavigationHandler({
+        prisma,
+        auth: mock.fn(async () => {
+            throw new Error("auth should not run when roleId is provided");
+        }),
+    });
+
+    const response = await handler(new Request("https://example.com/api/navigation?roleId=2"));
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), expectedNavigation);
+
+    assert.equal(navigationFindMany.mock.callCount(), 1);
+    const call = navigationFindMany.mock.calls[0];
+    assert.ok(call);
+    const [rawQuery] = call.arguments as unknown as [unknown];
+    assert.ok(rawQuery && typeof rawQuery === "object");
+    const query = rawQuery as { where: { roleId: number } };
+    assert.equal(query.where.roleId, 2);
+});
+
+test("falls back to the authenticated user's role when roleId is omitted", async () => {
+    process.env.DATABASE_URL = "postgres://test";
+    process.env.CLERK_SECRET_KEY = "sk_test";
+
+    const authMock = mock.fn(async () => ({ userId: "user_abc" }));
+    const findFirstMock = mock.fn(async () => ({ roleId: 5 }));
+    const navigationResult = [
+        {
+            navigationName: "Settings",
+            href: "/settings",
+            icon: "cog",
+            current: true,
+            sortOrder: 2,
+        },
+    ];
+    const navigationFindMany = mock.fn(async () => navigationResult);
+
+    const prisma = {
+        navigation: { findMany: navigationFindMany },
+        user: { findFirst: findFirstMock },
+    } as unknown as Parameters<typeof createNavigationHandler>[0]["prisma"];
+
+    const handler = createNavigationHandler({ prisma, auth: authMock });
+
+    const response = await handler(new Request("https://example.com/api/navigation"));
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), navigationResult);
+
+    assert.equal(authMock.mock.callCount(), 1);
+    assert.equal(findFirstMock.mock.callCount(), 1);
+    const call = navigationFindMany.mock.calls[0];
+    assert.ok(call);
+    const [rawQuery] = call.arguments as unknown as [unknown];
+    assert.ok(rawQuery && typeof rawQuery === "object");
+    const query = rawQuery as { where: { roleId: number } };
+    assert.equal(query.where.roleId, 5);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-tests",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2020",
+    "baseUrl": ".",
+    "types": ["node"],
+    "allowJs": false,
+    "rootDir": "."
+  },
+  "include": ["tests/**/*.ts", "app/api/navigation/navigation-handler.ts"]
+}


### PR DESCRIPTION
## Summary
- parse the `roleId` query parameter for the navigation API and validate it before querying
- keep the existing Clerk-based fallback when no `roleId` is provided
- add Node test coverage and supporting config/scripts for the navigation handler

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cce8c8e66c8320bfc1f72c58f16240