### PR TITLE
Add roleId query parameter to navigation fetch

### DIFF
--- a/components/layout/SidebarLayout.tsx
+++ b/components/layout/SidebarLayout.tsx
@@ -28,7 +28,7 @@ export default function SidebarLayout({
 
         const fetchNavigation = async () => {
             try {
-                const response = await fetch("/api/navigation");
+                const response = await fetch("/api/navigation?roleId=1");
 
                 if (!response.ok) {
                     console.error(


### PR DESCRIPTION
## Summary
- add a default `roleId=1` query parameter when requesting navigation data so the sidebar can request role-specific items
- retain the existing parsing and mapping logic so navigation rendering remains unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cceeca3f148320a9d946d4609696f8