### PR TITLE
Wrap role sync in effect

### DIFF
--- a/components/layout/SidebarLayout.tsx
+++ b/components/layout/SidebarLayout.tsx
@@ -35,14 +35,26 @@ export default function SidebarLayout({
 
     console.log("Current Route:", currentRoute);
 
-    if (currentRoute === "/") {
-        setRoleId(1); // Example roleId for home page
-    } else {
-        const matchedRole = roleRouteTable.find(
-            (entry) => entry.route === currentRoute
-        );
-        setRoleId(matchedRole ? matchedRole.roleId : null);
-    }
+    useEffect(() => {
+        if (!currentRoute) {
+            return;
+        }
+
+        let newRole: number | null;
+
+        if (currentRoute === "/") {
+            newRole = 1; // Example roleId for home page
+        } else {
+            const matchedRole = roleRouteTable.find(
+                (entry) => entry.route === currentRoute
+            );
+            newRole = matchedRole ? matchedRole.roleId : null;
+        }
+
+        if (newRole !== roleId) {
+            setRoleId(newRole);
+        }
+    }, [currentRoute, roleId]);
 
     useEffect(() => {
         interface NavigationApiItem {


### PR DESCRIPTION
## Summary
- move the role matching logic into a useEffect that runs after render and depends on the current route
- compute the role id from the current route inside the effect and avoid redundant state updates by checking against the existing role id

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd03e3b2bc83208a1eaf7fd11f6c67