### PR TITLE
Ensure navigation refetches on role change

### DIFF
--- a/components/layout/SidebarLayout.tsx
+++ b/components/layout/SidebarLayout.tsx
@@ -58,6 +58,10 @@ export default function SidebarLayout({
     }, [currentRoute, roleId]);
 
     useEffect(() => {
+        if (roleId === null) {
+            return;
+        }
+
         interface NavigationApiItem {
             navigationName: string;
             href: string;
@@ -67,8 +71,8 @@ export default function SidebarLayout({
         }
 
         const fetchNavigation = async () => {
-            try {                
-                const response = await fetch(`/api/navigation?roleId=${roleId ?? 1}`);
+            try {
+                const response = await fetch(`/api/navigation?roleId=${roleId}`);
 
                 if (!response.ok) {
                     console.error(
@@ -127,7 +131,7 @@ export default function SidebarLayout({
         };
 
         fetchNavigation();
-    }, []);
+    }, [roleId]);
 
     return (
         <div className="min-h-screen flex bg-white text-black">


### PR DESCRIPTION
## Summary
- guard the sidebar navigation fetch until a roleId has been resolved
- re-run the navigation fetch whenever the role changes so links stay in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd0ed2d1a08320bb0a4e8b205f4e1d