### PR TITLE
Update navigation handler to use applicationId

### DIFF
--- a/app/api/navigation/navigation-handler.ts
+++ b/app/api/navigation/navigation-handler.ts
@@ -7,7 +7,7 @@ export type NavigationHandlerDependencies = {
             findMany: (...args: unknown[]) => Promise<unknown>;
         };
         user: {
-            findFirst: (...args: unknown[]) => Promise<{ roleId: number } | null>;
+            findFirst: (...args: unknown[]) => Promise<{ applicationId: number } | null>;
         };
     };
     auth: () => Promise<{ userId: string | null } | null>;
@@ -21,22 +21,22 @@ const navigationSelect = {
     sortOrder: true,
 } as const;
 
-function parseRoleIdFromRequest(request: Request | NextRequest) {
-    const roleIdParam = new URL(request.url).searchParams.get("roleId");
-    if (roleIdParam === null) {
-        return { parsedRoleId: undefined } as const;
+function parseApplicationIdFromRequest(request: Request | NextRequest) {
+    const applicationIdParam = new URL(request.url).searchParams.get("applicationId");
+    if (applicationIdParam === null) {
+        return { parsedApplicationId: undefined } as const;
     }
 
-    const trimmed = roleIdParam.trim();
-    const parsedRoleId = Number.parseInt(trimmed, 10);
+    const trimmed = applicationIdParam.trim();
+    const parsedApplicationId = Number.parseInt(trimmed, 10);
 
-    if (!Number.isInteger(parsedRoleId) || parsedRoleId <= 0) {
+    if (!Number.isInteger(parsedApplicationId) || parsedApplicationId <= 0) {
         return {
-            error: "roleId must be a positive integer",
+            error: "applicationId must be a positive integer",
         } as const;
     }
 
-    return { parsedRoleId } as const;
+    return { parsedApplicationId } as const;
 }
 
 export function createNavigationHandler({ prisma: prismaClient, auth: authFn }: NavigationHandlerDependencies) {
@@ -46,14 +46,14 @@ export function createNavigationHandler({ prisma: prismaClient, auth: authFn }: 
                 throw new Error("Missing environment variables: DATABASE_URL");
             }
 
-            const { parsedRoleId, error } = parseRoleIdFromRequest(request);
+            const { parsedApplicationId, error } = parseApplicationIdFromRequest(request);
             if (error) {
                 return NextResponse.json({ error }, { status: 400 });
             }
 
-            if (typeof parsedRoleId === "number") {
+            if (typeof parsedApplicationId === "number") {
                 const navigation = await prismaClient.navigation.findMany({
-                    where: { roleId: parsedRoleId },
+                    where: { applicationId: parsedApplicationId },
                     orderBy: { sortOrder: "asc" },
                     select: navigationSelect,
                 });
@@ -77,7 +77,7 @@ export function createNavigationHandler({ prisma: prismaClient, auth: authFn }: 
             }
 
             const navigation = await prismaClient.navigation.findMany({
-                where: { roleId: user.roleId },
+                where: { applicationId: user.applicationId },
                 orderBy: { sortOrder: "asc" },
                 select: navigationSelect,
             });


### PR DESCRIPTION
## Summary
- update the navigation handler to parse an `applicationId` query parameter with appropriate validation
- query navigation entries by `applicationId`, including the authenticated user fallback branch
- adjust the handler dependencies so fetched users surface their `applicationId`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7d42de1c83208580a4ae6fdd8420