### PR TITLE
Update navigation handler applicationId filtering

### DIFF
--- a/app/api/navigation/navigation-handler.ts
+++ b/app/api/navigation/navigation-handler.ts
@@ -7,7 +7,7 @@ export type NavigationHandlerDependencies = {
             findMany: (...args: unknown[]) => Promise<unknown>;
         };
         user: {
-            findFirst: (...args: unknown[]) => Promise<{ roleId: number } | null>;
+            findFirst: (...args: unknown[]) => Promise<{ applicationId: number } | null>;
         };
     };
     auth: () => Promise<{ userId: string | null } | null>;
@@ -21,22 +21,22 @@ const navigationSelect = {
     sortOrder: true,
 } as const;
 
-function parseRoleIdFromRequest(request: Request | NextRequest) {
-    const roleIdParam = new URL(request.url).searchParams.get("roleId");
-    if (roleIdParam === null) {
-        return { parsedRoleId: undefined } as const;
+function parseApplicationIdFromRequest(request: Request | NextRequest) {
+    const applicationIdParam = new URL(request.url).searchParams.get("applicationId");
+    if (applicationIdParam === null) {
+        return { parsedApplicationId: undefined } as const;
     }
 
-    const trimmed = roleIdParam.trim();
-    const parsedRoleId = Number.parseInt(trimmed, 10);
+    const trimmed = applicationIdParam.trim();
+    const parsedApplicationId = Number.parseInt(trimmed, 10);
 
-    if (!Number.isInteger(parsedRoleId) || parsedRoleId <= 0) {
+    if (!Number.isInteger(parsedApplicationId) || parsedApplicationId <= 0) {
         return {
-            error: "roleId must be a positive integer",
+            error: "applicationId must be a positive integer",
         } as const;
     }
 
-    return { parsedRoleId } as const;
+    return { parsedApplicationId } as const;
 }
 
 export function createNavigationHandler({ prisma: prismaClient, auth: authFn }: NavigationHandlerDependencies) {
@@ -46,14 +46,14 @@ export function createNavigationHandler({ prisma: prismaClient, auth: authFn }: 
                 throw new Error("Missing environment variables: DATABASE_URL");
             }
 
-            const { parsedRoleId, error } = parseRoleIdFromRequest(request);
+            const { parsedApplicationId, error } = parseApplicationIdFromRequest(request);
             if (error) {
                 return NextResponse.json({ error }, { status: 400 });
             }
 
-            if (typeof parsedRoleId === "number") {
+            if (typeof parsedApplicationId === "number") {
                 const navigation = await prismaClient.navigation.findMany({
-                    where: { roleId: parsedRoleId },
+                    where: { applicationId: parsedApplicationId },
                     orderBy: { sortOrder: "asc" },
                     select: navigationSelect,
                 });
@@ -77,7 +77,7 @@ export function createNavigationHandler({ prisma: prismaClient, auth: authFn }: 
             }
 
             const navigation = await prismaClient.navigation.findMany({
-                where: { roleId: user.roleId },
+                where: { applicationId: user.applicationId },
                 orderBy: { sortOrder: "asc" },
                 select: navigationSelect,
             });

--- a/tests/api/navigation.route.test.ts
+++ b/tests/api/navigation.route.test.ts
@@ -3,7 +3,7 @@ import { mock, test } from "node:test";
 
 import { createNavigationHandler } from "../../app/api/navigation/navigation-handler";
 
-test("returns 400 when roleId query parameter is invalid", async () => {
+test("returns 400 when applicationId query parameter is invalid", async () => {
     process.env.DATABASE_URL = "postgres://test";
 
     const navigationFindMany = mock.fn(async () => []);
@@ -17,13 +17,13 @@ test("returns 400 when roleId query parameter is invalid", async () => {
         auth: async () => ({ userId: "user_123" }),
     });
 
-    const response = await handler(new Request("https://example.com/api/navigation?roleId=abc"));
+    const response = await handler(new Request("https://example.com/api/navigation?applicationId=abc"));
     assert.equal(response.status, 400);
-    assert.deepEqual(await response.json(), { error: "roleId must be a positive integer" });
+    assert.deepEqual(await response.json(), { error: "applicationId must be a positive integer" });
     assert.equal(navigationFindMany.mock.callCount(), 0);
 });
 
-test("filters navigation by provided roleId", async () => {
+test("filters navigation by provided applicationId", async () => {
     process.env.DATABASE_URL = "postgres://test";
 
     const expectedNavigation = [
@@ -41,7 +41,7 @@ test("filters navigation by provided roleId", async () => {
         navigation: { findMany: navigationFindMany },
         user: {
             findFirst: mock.fn(async () => {
-                throw new Error("user lookup should not run when roleId is provided");
+                throw new Error("user lookup should not run when applicationId is provided");
             }),
         },
     } as unknown as Parameters<typeof createNavigationHandler>[0]["prisma"];
@@ -49,11 +49,11 @@ test("filters navigation by provided roleId", async () => {
     const handler = createNavigationHandler({
         prisma,
         auth: mock.fn(async () => {
-            throw new Error("auth should not run when roleId is provided");
+            throw new Error("auth should not run when applicationId is provided");
         }),
     });
 
-    const response = await handler(new Request("https://example.com/api/navigation?roleId=2"));
+    const response = await handler(new Request("https://example.com/api/navigation?applicationId=2"));
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), expectedNavigation);
 
@@ -62,16 +62,16 @@ test("filters navigation by provided roleId", async () => {
     assert.ok(call);
     const [rawQuery] = call.arguments as unknown as [unknown];
     assert.ok(rawQuery && typeof rawQuery === "object");
-    const query = rawQuery as { where: { roleId: number } };
-    assert.equal(query.where.roleId, 2);
+    const query = rawQuery as { where: { applicationId: number } };
+    assert.equal(query.where.applicationId, 2);
 });
 
-test("falls back to the authenticated user's role when roleId is omitted", async () => {
+test("falls back to the authenticated user's application when applicationId is omitted", async () => {
     process.env.DATABASE_URL = "postgres://test";
     process.env.CLERK_SECRET_KEY = "sk_test";
 
     const authMock = mock.fn(async () => ({ userId: "user_abc" }));
-    const findFirstMock = mock.fn(async () => ({ roleId: 5 }));
+    const findFirstMock = mock.fn(async () => ({ applicationId: 5 }));
     const navigationResult = [
         {
             navigationName: "Settings",
@@ -100,6 +100,6 @@ test("falls back to the authenticated user's role when roleId is omitted", async
     assert.ok(call);
     const [rawQuery] = call.arguments as unknown as [unknown];
     assert.ok(rawQuery && typeof rawQuery === "object");
-    const query = rawQuery as { where: { roleId: number } };
-    assert.equal(query.where.roleId, 5);
+    const query = rawQuery as { where: { applicationId: number } };
+    assert.equal(query.where.applicationId, 5);
 });


### PR DESCRIPTION
## Summary
- update the navigation API handler to accept an `applicationId` query parameter and use it when fetching navigation
- adjust the mocked user lookup and navigation tests to reference `applicationId`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7d45cf4c83208866c1558299f9db