### PR TITLE
Add subnavigation data to navigation API responses

### DIFF
--- a/app/api/navigation/navigation-handler.ts
+++ b/app/api/navigation/navigation-handler.ts
@@ -1,25 +1,58 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-export type NavigationHandlerDependencies = {
-    prisma: {
-        navigation: {
-            findMany: (...args: unknown[]) => Promise<unknown>;
-        };
-        user: {
-            findFirst: (...args: unknown[]) => Promise<{ applicationId: number } | null>;
-        };
-    };
-    auth: () => Promise<{ userId: string | null } | null>;
-};
-
 const navigationSelect = {
     navigationName: true,
     href: true,
     icon: true,
     current: true,
     sortOrder: true,
+    subnavigation: {
+        orderBy: { sortOrder: "asc" as const },
+        select: {
+            subNavigationName: true,
+            href: true,
+            icon: true,
+            current: true,
+            sortOrder: true,
+        },
+    },
 } as const;
+
+type NavigationPayload = {
+    navigationName: string;
+    href: string;
+    icon: string;
+    current: boolean;
+    sortOrder: number | null;
+    subnavigation: {
+        subNavigationName: string;
+        href: string;
+        icon: string | null;
+        current: boolean | null;
+        sortOrder: number | null;
+    }[];
+};
+
+type NavigationFindManyArgs = {
+    where: { applicationId: number };
+    orderBy: { sortOrder: "asc" | "desc" | null };
+    select: typeof navigationSelect;
+};
+
+type UserFindFirstArgs = { where: { clerkId: string } };
+
+export type NavigationHandlerDependencies = {
+    prisma: {
+        navigation: {
+            findMany: (args: NavigationFindManyArgs) => Promise<NavigationPayload[]>;
+        };
+        user: {
+            findFirst: (args: UserFindFirstArgs) => Promise<{ applicationId: number } | null>;
+        };
+    };
+    auth: () => Promise<{ userId: string | null } | null>;
+};
 
 function parseApplicationIdFromRequest(request: Request | NextRequest) {
     const applicationIdParam = new URL(request.url).searchParams.get("applicationId");

--- a/tests/api/navigation.route.test.ts
+++ b/tests/api/navigation.route.test.ts
@@ -33,6 +33,15 @@ test("filters navigation by provided applicationId", async () => {
             icon: "home",
             current: false,
             sortOrder: 1,
+            subnavigation: [
+                {
+                    subNavigationName: "Overview",
+                    href: "/dashboard/overview",
+                    icon: "chart",
+                    current: false,
+                    sortOrder: 1,
+                },
+            ],
         },
     ];
 
@@ -55,7 +64,9 @@ test("filters navigation by provided applicationId", async () => {
 
     const response = await handler(new Request("https://example.com/api/navigation?applicationId=2"));
     assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), expectedNavigation);
+    const payload = await response.json();
+    assert.deepEqual(payload, expectedNavigation);
+    assert.deepEqual(payload[0]?.subnavigation, expectedNavigation[0]?.subnavigation);
 
     assert.equal(navigationFindMany.mock.callCount(), 1);
     const call = navigationFindMany.mock.calls[0];
@@ -79,6 +90,15 @@ test("falls back to the authenticated user's application when applicationId is o
             icon: "cog",
             current: true,
             sortOrder: 2,
+            subnavigation: [
+                {
+                    subNavigationName: "Profile",
+                    href: "/settings/profile",
+                    icon: "user",
+                    current: true,
+                    sortOrder: 1,
+                },
+            ],
         },
     ];
     const navigationFindMany = mock.fn(async () => navigationResult);
@@ -92,7 +112,9 @@ test("falls back to the authenticated user's application when applicationId is o
 
     const response = await handler(new Request("https://example.com/api/navigation"));
     assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), navigationResult);
+    const payload = await response.json();
+    assert.deepEqual(payload, navigationResult);
+    assert.deepEqual(payload[0]?.subnavigation, navigationResult[0]?.subnavigation);
 
     assert.equal(authMock.mock.callCount(), 1);
     assert.equal(findFirstMock.mock.callCount(), 1);


### PR DESCRIPTION
## Summary
- include subnavigation records when fetching navigation items and type the handler dependencies to match the nested payload
- extend the navigation route tests to assert the subnavigation array is returned for direct and inferred application lookups

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce870c7ad0832084dc665b44bb7d95