### PR TITLE
Allow sidebar horizontal overflow

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -161,7 +161,7 @@ export default function Sidebar({ navigation }: SidebarProps) {
     return (
         <>
             {/* Sidebar component, swap this element with another sidebar if you like */}
-            <div className="fixed flex flex-col h-full w-64 gap-y-5 overflow-y-auto bg-gray-900 px-6 pb-4 ring-1 ring-white/10">
+            <div className="fixed flex flex-col h-full w-64 gap-y-5 overflow-y-auto overflow-x-visible bg-gray-900 px-6 pb-4 ring-1 ring-white/10">
                 <div className="flex h-16 shrink-0 items-center">
                     <Image
                         alt="ERIC ERP"


### PR DESCRIPTION
## Summary
- allow the fixed sidebar container to expose horizontal overflow so popovers can render outside its width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce8afd7d988320b9b1be7375b881b1