### PR TITLE
Use shared prisma client in general ledger route

### DIFF
--- a/app/api/finance-accounting/general-ledger/route.ts
+++ b/app/api/finance-accounting/general-ledger/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 export async function GET(req: NextRequest) {
     try {


### PR DESCRIPTION
## Summary
- replace the general ledger API route's inline Prisma client creation with the shared client import

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cece4fb1008320b2156abd532c5aa0