### PR TITLE
Refactor chart of accounts table into sortable client component

### DIFF
--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/ChartOfAccountsTable.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/ChartOfAccountsTable.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { Account } from "@prisma/client";
+
+type SortKey = "code" | "name";
+type SortDirection = "asc" | "desc";
+
+type SortConfig = {
+    key: SortKey;
+    direction: SortDirection;
+};
+
+type ChartOfAccountsTableProps = {
+    accounts: Account[];
+};
+
+const directionLabels: Record<SortDirection, string> = {
+    asc: "ascending",
+    desc: "descending",
+};
+
+const getSortDescription = (
+    sortConfig: SortConfig,
+    column: SortKey,
+) => {
+    if (sortConfig.key === column) {
+        return `currently sorted ${directionLabels[sortConfig.direction]}`;
+    }
+
+    return "currently unsorted";
+};
+
+function getAriaSort(
+    sortConfig: SortConfig,
+    column: SortKey,
+): "ascending" | "descending" | "none" {
+    if (sortConfig.key !== column) {
+        return "none";
+    }
+
+    return sortConfig.direction === "asc" ? "ascending" : "descending";
+}
+
+const SortIndicator = ({
+    active,
+    direction,
+}: {
+    active: boolean;
+    direction: SortDirection;
+}) => (
+    <span aria-hidden="true" className="text-xs">
+        {active ? (direction === "asc" ? "▲" : "▼") : "↕"}
+    </span>
+);
+
+export default function ChartOfAccountsTable({
+    accounts,
+}: ChartOfAccountsTableProps) {
+    const [sortConfig, setSortConfig] = useState<SortConfig>({
+        key: "code",
+        direction: "asc",
+    });
+
+    const sortedAccounts = useMemo(() => {
+        const sorted = [...accounts];
+
+        sorted.sort((a, b) => {
+            const valueA = a[sortConfig.key];
+            const valueB = b[sortConfig.key];
+
+            if (valueA === valueB) {
+                return 0;
+            }
+
+            const stringA = valueA == null ? "" : String(valueA);
+            const stringB = valueB == null ? "" : String(valueB);
+
+            if (sortConfig.direction === "asc") {
+                return stringA.localeCompare(stringB, undefined, { sensitivity: "base" });
+            }
+
+            return stringB.localeCompare(stringA, undefined, { sensitivity: "base" });
+        });
+
+        return sorted;
+    }, [accounts, sortConfig]);
+
+    const handleSort = (key: SortKey) => {
+        setSortConfig((current) => {
+            if (current.key === key) {
+                return {
+                    key,
+                    direction: current.direction === "asc" ? "desc" : "asc",
+                };
+            }
+
+            return {
+                key,
+                direction: "asc",
+            };
+        });
+    };
+
+    return (
+        <table className="relative min-w-full divide-y divide-gray-300">
+            <thead className="bg-gray-50">
+                <tr>
+                    <th
+                        scope="col"
+                        className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                        aria-sort={getAriaSort(sortConfig, "code")}
+                    >
+                        <button
+                            type="button"
+                            onClick={() => handleSort("code")}
+                            className="flex items-center gap-1 text-left font-semibold text-gray-900 focus:outline-none focus-visible:underline"
+                        >
+                            <span>Code</span>
+                            <SortIndicator
+                                active={sortConfig.key === "code"}
+                                direction={sortConfig.direction}
+                            />
+                            <span className="sr-only">
+                                Sort by code, {getSortDescription(sortConfig, "code")}
+                            </span>
+                        </button>
+                    </th>
+                    <th
+                        scope="col"
+                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                        aria-sort={getAriaSort(sortConfig, "name")}
+                    >
+                        <button
+                            type="button"
+                            onClick={() => handleSort("name")}
+                            className="flex items-center gap-1 text-left font-semibold text-gray-900 focus:outline-none focus-visible:underline"
+                        >
+                            <span>Name</span>
+                            <SortIndicator
+                                active={sortConfig.key === "name"}
+                                direction={sortConfig.direction}
+                            />
+                            <span className="sr-only">
+                                Sort by name, {getSortDescription(sortConfig, "name")}
+                            </span>
+                        </button>
+                    </th>
+                    <th
+                        scope="col"
+                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    >
+                        Type
+                    </th>
+                    <th
+                        scope="col"
+                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    >
+                        Normal Balance
+                    </th>
+                    <th
+                        scope="col"
+                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    >
+                        Status
+                    </th>
+                </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white">
+                {sortedAccounts.map((account) => (
+                    <tr key={account.id}>
+                        <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                            {account.code}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                            {account.name}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                            {account.type}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                            {account.normal_balance}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                            {account.status}
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}

--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
@@ -1,5 +1,6 @@
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import PageHeader from "@/components/layout/PageHeader";
+import ChartOfAccountsTable from "./ChartOfAccountsTable";
 import { prisma } from "@/lib/prisma";
 import { RedirectToSignIn, SignedIn, SignedOut } from "@clerk/nextjs";
 
@@ -48,63 +49,7 @@ export default async function ChartOfAccountsPage() {
                                             No accounts found.
                                         </div>
                                     ) : (
-                                        <table className="relative min-w-full divide-y divide-gray-300">
-                                            <thead className="bg-gray-50">
-                                                <tr>
-                                                    <th
-                                                        scope="col"
-                                                        className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
-                                                    >
-                                                        Code
-                                                    </th>
-                                                    <th
-                                                        scope="col"
-                                                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                                                    >
-                                                        Name
-                                                    </th>
-                                                    <th
-                                                        scope="col"
-                                                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                                                    >
-                                                        Type
-                                                    </th>
-                                                    <th
-                                                        scope="col"
-                                                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                                                    >
-                                                        Normal Balance
-                                                    </th>
-                                                    <th
-                                                        scope="col"
-                                                        className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
-                                                    >
-                                                        Status
-                                                    </th>
-                                                </tr>
-                                            </thead>
-                                            <tbody className="divide-y divide-gray-200 bg-white">
-                                                {accounts.map((account) => (
-                                                    <tr key={account.id}>
-                                                        <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                                                            {account.code}
-                                                        </td>
-                                                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                                                            {account.name}
-                                                        </td>
-                                                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                                                            {account.type}
-                                                        </td>
-                                                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                                                            {account.normal_balance}
-                                                        </td>
-                                                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                                                            {account.status}
-                                                        </td>
-                                                    </tr>
-                                                ))}
-                                            </tbody>
-                                        </table>
+                                        <ChartOfAccountsTable accounts={accounts} />
                                     )}
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- move the chart of accounts table rendering into a dedicated client component
- add interactive column sorting for account code and name with accessible controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee3f3ef6c83208c50e0675efb2c88