### PR TITLE
Wrap chart of accounts table in scrollable container

### DIFF
--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
@@ -49,8 +49,9 @@ export default async function ChartOfAccountsPage() {
                                             No accounts found.
                                         </div>
                                     ) : (
-
-                                        <ChartOfAccountsTable accounts={accounts} />
+                                        <div className="flex-1 min-h-0 min-w-full overflow-y-auto overflow-x-auto">
+                                            <ChartOfAccountsTable accounts={accounts} />
+                                        </div>
                                     )}
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- wrap the chart of accounts table in a flex item that enables vertical scrolling within the page layout
- preserve the surrounding horizontal scroll container so the table can still expand to full width

## Testing
- `npm run dev` *(fails: Clerk handshake requires credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cee764f95c8320b6dee8009d9eb1dd