### PR TITLE
Add account creation API and include ledger in save payload

### DIFF
--- a/app/api/finance-accounting/accounts/route.ts
+++ b/app/api/finance-accounting/accounts/route.ts
@@ -1,11 +1,99 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 
-export async function GET(req: NextRequest) {
+const ACCOUNT_TYPES = ['ASSET', 'LIABILITY', 'EQUITY', 'REVENUE', 'EXPENSE'] as const;
+type AccountType = (typeof ACCOUNT_TYPES)[number];
+
+const NORMAL_BALANCES = ['DEBIT', 'CREDIT'] as const;
+type NormalBalance = (typeof NORMAL_BALANCES)[number];
+
+export async function GET() {
     try {
         const accounts = await prisma.account.findMany();
         return NextResponse.json(accounts);
     } catch (error) {
+        console.error('Failed to fetch accounts', error);
         return NextResponse.json({ error: 'Failed to fetch accounts' }, { status: 500 });
+    }
+}
+
+export async function POST(req: NextRequest) {
+    try {
+        const body = await req.json();
+
+        if (!body || typeof body !== 'object') {
+            return NextResponse.json({ error: 'Invalid request payload' }, { status: 400 });
+        }
+
+        const {
+            code,
+            name,
+            description,
+            level,
+            parent_id,
+            type,
+            normal_balance,
+            is_postable,
+            status,
+            ledger_id,
+        } = body as Record<string, unknown>;
+
+        if (
+            typeof code !== 'string' ||
+            code.trim() === '' ||
+            typeof name !== 'string' ||
+            name.trim() === '' ||
+            typeof ledger_id !== 'string' ||
+            ledger_id.trim() === ''
+        ) {
+            return NextResponse.json(
+                { error: 'Code, name, and ledger_id are required fields.' },
+                { status: 400 }
+            );
+        }
+
+        const accountType =
+            typeof type === 'string' && ACCOUNT_TYPES.includes(type.toUpperCase() as AccountType)
+                ? (type.toUpperCase() as AccountType)
+                : 'ASSET';
+
+        const normalBalance =
+            typeof normal_balance === 'string' &&
+            NORMAL_BALANCES.includes(normal_balance.toUpperCase() as NormalBalance)
+                ? (normal_balance.toUpperCase() as NormalBalance)
+                : 'DEBIT';
+
+        const parsedLevel =
+            typeof level === 'number' && Number.isFinite(level)
+                ? Math.trunc(level)
+                : 0;
+
+        const parentId =
+            typeof parent_id === 'string' && parent_id.trim() !== '' ? parent_id : null;
+
+        const sanitizedDescription =
+            typeof description === 'string' && description.trim() !== ''
+                ? description.trim()
+                : null;
+
+        const newAccount = await prisma.account.create({
+            data: {
+                ledger_id: ledger_id.trim(),
+                code: code.trim(),
+                name: name.trim(),
+                description: sanitizedDescription,
+                level: parsedLevel,
+                parent_id: parentId,
+                type: accountType,
+                normal_balance: normalBalance,
+                is_postable: Boolean(is_postable),
+                status: typeof status === 'string' && status.trim() !== '' ? status.trim() : 'ACTIVE',
+            },
+        });
+
+        return NextResponse.json(newAccount, { status: 201 });
+    } catch (error) {
+        console.error('Failed to create account', error);
+        return NextResponse.json({ error: 'Failed to create account' }, { status: 500 });
     }
 }

--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
@@ -28,7 +28,10 @@ type Account = {
     type: string;
     normal_balance: string;
     status: string;
-    [key: string]: unknown;
+    ledger_id: string;
+    parent_id: string | null;
+    level: number;
+    description?: string | null;
 };
 
 export default function ChartOfAccountsPage() {
@@ -82,6 +85,28 @@ export default function ChartOfAccountsPage() {
             level = Number.isNaN(parsedLevel) ? null : parsedLevel;
         }
 
+        const selectedParentId =
+            typeof parentAccount === "string" && parentAccount !== ""
+                ? parentAccount
+                : null;
+
+        let ledgerId: string | null = null;
+        if (selectedParentId) {
+            const parentAccountDetails = accounts.find(
+                (account) => account.id === selectedParentId
+            );
+            ledgerId = parentAccountDetails?.ledger_id ?? null;
+        }
+
+        if (!ledgerId && accounts.length > 0) {
+            ledgerId = accounts[0]?.ledger_id ?? null;
+        }
+
+        if (!ledgerId) {
+            setError("Unable to determine the ledger for the new account.");
+            return;
+        }
+
         const payload = {
             code: typeof code === "string" ? code : "",
             name: typeof name === "string" ? name : "",
@@ -89,11 +114,8 @@ export default function ChartOfAccountsPage() {
                 typeof description === "string" && description.trim() !== ""
                     ? description
                     : null,
-            level,
-            parent_id:
-                typeof parentAccount === "string" && parentAccount !== ""
-                    ? parentAccount
-                    : null,
+            level: level ?? 0,
+            parent_id: selectedParentId,
             type:
                 typeof accountType === "string" && accountType !== ""
                     ? accountType
@@ -101,6 +123,7 @@ export default function ChartOfAccountsPage() {
             normal_balance: normalBalance,
             is_postable: formData.get("is-postable") === "on",
             status: formData.get("is-active") === "on" ? "ACTIVE" : "INACTIVE",
+            ledger_id: ledgerId,
         };
 
         try {


### PR DESCRIPTION
## Summary
- add a POST handler for the finance accounting accounts API that validates input and persists new records via Prisma
- normalise client form submission by deriving the active ledger id and including it in the save payload
- surface a friendly validation error when a ledger cannot be determined before submitting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d123a202548320b57e0b91db7a766d