### PR TITLE
Add chart of accounts editing flow

### DIFF
--- a/app/api/finance-accounting/accounts/[id]/route.ts
+++ b/app/api/finance-accounting/accounts/[id]/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+const ACCOUNT_TYPES = [
+    "ASSET",
+    "LIABILITY",
+    "EQUITY",
+    "REVENUE",
+    "EXPENSE",
+] as const;
+type AccountType = (typeof ACCOUNT_TYPES)[number];
+
+const NORMAL_BALANCES = ["DEBIT", "CREDIT"] as const;
+type NormalBalance = (typeof NORMAL_BALANCES)[number];
+
+export async function PUT(
+    req: NextRequest,
+    { params }: { params: { id: string } }
+) {
+    const accountId = params.id;
+
+    if (!accountId || typeof accountId !== "string") {
+        return NextResponse.json({ error: "Invalid account id" }, { status: 400 });
+    }
+
+    try {
+        const body = await req.json();
+
+        if (!body || typeof body !== "object") {
+            return NextResponse.json(
+                { error: "Invalid request payload" },
+                { status: 400 }
+            );
+        }
+
+        const {
+            code,
+            name,
+            description,
+            level,
+            parent_id,
+            type,
+            normal_balance,
+            is_postable,
+            status,
+            ledger_id,
+        } = body as Record<string, unknown>;
+
+        if (
+            typeof code !== "string" ||
+            code.trim() === "" ||
+            typeof name !== "string" ||
+            name.trim() === "" ||
+            typeof ledger_id !== "string" ||
+            ledger_id.trim() === ""
+        ) {
+            return NextResponse.json(
+                { error: "Code, name, and ledger_id are required fields." },
+                { status: 400 }
+            );
+        }
+
+        const accountType =
+            typeof type === "string" && ACCOUNT_TYPES.includes(type.toUpperCase() as AccountType)
+                ? (type.toUpperCase() as AccountType)
+                : "ASSET";
+
+        const normalBalance =
+            typeof normal_balance === "string" &&
+            NORMAL_BALANCES.includes(normal_balance.toUpperCase() as NormalBalance)
+                ? (normal_balance.toUpperCase() as NormalBalance)
+                : "DEBIT";
+
+        const parsedLevel =
+            typeof level === "number" && Number.isFinite(level)
+                ? Math.trunc(level)
+                : 0;
+
+        const parentId =
+            typeof parent_id === "string" && parent_id.trim() !== "" ? parent_id : null;
+
+        const sanitizedDescription =
+            typeof description === "string" && description.trim() !== ""
+                ? description.trim()
+                : null;
+
+        const updatedAccount = await prisma.account.update({
+            where: { id: accountId },
+            data: {
+                ledger_id: ledger_id.trim(),
+                code: code.trim(),
+                name: name.trim(),
+                description: sanitizedDescription,
+                level: parsedLevel,
+                parent_id: parentId,
+                type: accountType,
+                normal_balance: normalBalance,
+                is_postable: Boolean(is_postable),
+                status:
+                    typeof status === "string" && status.trim() !== ""
+                        ? status.trim()
+                        : "ACTIVE",
+            },
+        });
+
+        return NextResponse.json(updatedAccount);
+    } catch (error) {
+        if (
+            error instanceof Prisma.PrismaClientKnownRequestError &&
+            error.code === "P2025"
+        ) {
+            return NextResponse.json({ error: "Account not found" }, { status: 404 });
+        }
+
+        console.error("Failed to update account", error);
+        return NextResponse.json(
+            { error: "Failed to update account" },
+            { status: 500 }
+        );
+    }
+}

--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/ChartOfAccountsTable.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/ChartOfAccountsTable.tsx
@@ -21,6 +21,7 @@ type SortConfig = {
 
 type ChartOfAccountsTableProps = {
     accounts: Account[];
+    onEdit: (accountId: string) => void;
 };
 
 const directionLabels: Record<SortDirection, string> = {
@@ -61,6 +62,7 @@ const SortIndicator = ({
 
 export default function ChartOfAccountsTable({
     accounts,
+    onEdit,
 }: ChartOfAccountsTableProps) {
     const [sortConfig, setSortConfig] = useState<SortConfig>({
         key: "code",
@@ -208,6 +210,7 @@ export default function ChartOfAccountsTable({
                                         type="button"
                                         className="text-indigo-600 hover:text-indigo-900"
                                         aria-label="Edit"
+                                        onClick={() => onEdit(account.id)}
                                     >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"

--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
@@ -32,12 +32,14 @@ type Account = {
     parent_id: string | null;
     level: number;
     description?: string | null;
+    is_postable: boolean;
 };
 
 export default function ChartOfAccountsPage() {
     const [open, setOpen] = useState(false);
     const [accounts, setAccounts] = useState<Account[]>([]);
     const [error, setError] = useState<string | null>(null);
+    const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
 
     useEffect(() => {
@@ -57,7 +59,102 @@ export default function ChartOfAccountsPage() {
         fetchAccounts();
     }, []);
 
+    useEffect(() => {
+        if (!formRef.current) {
+            return;
+        }
+
+        if (!selectedAccount) {
+            formRef.current.reset();
+            return;
+        }
+
+        const form = formRef.current;
+
+        const codeInput = form.elements.namedItem("code") as
+            | HTMLInputElement
+            | null;
+        if (codeInput) {
+            codeInput.value = selectedAccount.code;
+        }
+
+        const nameInput = form.elements.namedItem("name") as
+            | HTMLInputElement
+            | null;
+        if (nameInput) {
+            nameInput.value = selectedAccount.name;
+        }
+
+        const descriptionInput = form.elements.namedItem("description") as
+            | HTMLTextAreaElement
+            | null;
+        if (descriptionInput) {
+            descriptionInput.value = selectedAccount.description ?? "";
+        }
+
+        const levelInput = form.elements.namedItem("level") as
+            | HTMLInputElement
+            | null;
+        if (levelInput) {
+            levelInput.value = String(selectedAccount.level ?? "");
+        }
+
+        const parentSelect = form.elements.namedItem(
+            "parent-account"
+        ) as HTMLSelectElement | null;
+        if (parentSelect) {
+            parentSelect.value = selectedAccount.parent_id ?? "";
+        }
+
+        const accountTypeSelect = form.elements.namedItem(
+            "account-type"
+        ) as HTMLSelectElement | null;
+        if (accountTypeSelect) {
+            accountTypeSelect.value = selectedAccount.type ?? "ASSET";
+        }
+
+        const normalBalanceSelect = form.elements.namedItem(
+            "normal-balance"
+        ) as HTMLSelectElement | null;
+        if (normalBalanceSelect) {
+            normalBalanceSelect.value =
+                selectedAccount.normal_balance === "CREDIT"
+                    ? "Credit"
+                    : "Debit";
+        }
+
+        const isPostableInput = form.elements.namedItem("is-postable") as
+            | HTMLInputElement
+            | null;
+        if (isPostableInput) {
+            isPostableInput.checked = Boolean(selectedAccount.is_postable);
+        }
+
+        const isActiveInput = form.elements.namedItem("is-active") as
+            | HTMLInputElement
+            | null;
+        if (isActiveInput) {
+            isActiveInput.checked = selectedAccount.status === "ACTIVE";
+        }
+    }, [selectedAccount]);
+
     const isLoadingAccounts = !error && accounts.length === 0;
+
+    const handleClose = () => {
+        setOpen(false);
+        setSelectedAccount(null);
+        formRef.current?.reset();
+    };
+
+    const handleEdit = (accountId: string) => {
+        const accountToEdit = accounts.find((account) => account.id === accountId);
+        if (!accountToEdit) {
+            return;
+        }
+
+        setSelectedAccount(accountToEdit);
+        setOpen(true);
+    };
 
     const handleSave = async () => {
         if (!formRef.current) {
@@ -90,7 +187,7 @@ export default function ChartOfAccountsPage() {
                 ? parentAccount
                 : null;
 
-        let ledgerId: string | null = null;
+        let ledgerId: string | null = selectedAccount?.ledger_id ?? null;
         if (selectedParentId) {
             const parentAccountDetails = accounts.find(
                 (account) => account.id === selectedParentId
@@ -128,20 +225,45 @@ export default function ChartOfAccountsPage() {
 
         try {
             setError(null);
-            const response = await fetch("/api/finance-accounting/accounts", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify(payload),
-            });
+            if (selectedAccount) {
+                const response = await fetch(
+                    `/api/finance-accounting/accounts/${selectedAccount.id}`,
+                    {
+                        method: "PUT",
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify(payload),
+                    }
+                );
 
-            if (!response.ok) {
-                throw new Error("Network response was not ok");
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+
+                const updatedAccount = (await response.json()) as Account;
+                setAccounts((prevAccounts) =>
+                    prevAccounts.map((account) =>
+                        account.id === updatedAccount.id ? updatedAccount : account
+                    )
+                );
+                setSelectedAccount(null);
+            } else {
+                const response = await fetch("/api/finance-accounting/accounts", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(payload),
+                });
+
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+
+                const newAccount = (await response.json()) as Account;
+                setAccounts((prevAccounts) => [...prevAccounts, newAccount]);
             }
-
-            const newAccount = (await response.json()) as Account;
-            setAccounts((prevAccounts) => [...prevAccounts, newAccount]);
             formRef.current.reset();
             setOpen(false);
         } catch (saveError) {
@@ -164,7 +286,11 @@ export default function ChartOfAccountsPage() {
                         <button
                             type="button"
                             className="inline-flex items-center gap-2 rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            onClick={() => setOpen(true)}
+                            onClick={() => {
+                                setSelectedAccount(null);
+                                formRef.current?.reset();
+                                setOpen(true);
+                            }}
                         >
                             <svg
                                 xmlns="http://www.w3.org/2000/svg"
@@ -203,6 +329,7 @@ export default function ChartOfAccountsPage() {
                                             <div className="flex-1 min-h-0 min-w-full overflow-y-auto overflow-x-auto">
                                                 <ChartOfAccountsTable
                                                     accounts={accounts}
+                                                    onEdit={handleEdit}
                                                 />
                                             </div>
                                         </>
@@ -214,7 +341,7 @@ export default function ChartOfAccountsPage() {
 
                     <Dialog
                         open={open}
-                        onClose={setOpen}
+                        onClose={handleClose}
                         className="relative z-10"
                     >
                         <div className="fixed inset-0" />
@@ -230,14 +357,14 @@ export default function ChartOfAccountsPage() {
                                             <div className="bg-indigo-700 px-4 py-6 sm:px-6">
                                                 <div className="flex items-center justify-between">
                                                     <DialogTitle className="text-base font-semibold text-white">
-                                                        Add Chart of Account
+                                                        {selectedAccount
+                                                            ? "Edit Chart of Account"
+                                                            : "Add Chart of Account"}
                                                     </DialogTitle>
                                                     <div className="ml-3 flex h-7 items-center">
                                                         <button
                                                             type="button"
-                                                            onClick={() =>
-                                                                setOpen(false)
-                                                            }
+                                                            onClick={handleClose}
                                                             className="relative rounded-md text-indigo-200 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                                                         >
                                                             <span className="absolute -inset-2.5" />
@@ -505,9 +632,7 @@ export default function ChartOfAccountsPage() {
                                                 <button
                                                     type="button"
                                                     className="rounded px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-300"
-                                                    onClick={() =>
-                                                        setOpen(false)
-                                                    }
+                                                    onClick={handleClose}
                                                 >
                                                     Cancel
                                                 </button>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -386,15 +386,6 @@ export default function Sidebar({ navigation }: SidebarProps) {
                                                     >
                                                         {item.subnavigation?.map(
                                                             (child) => {
-                                                                const ChildIcon =
-                                                                    child.icon
-                                                                        ? iconMap[
-                                                                              child
-                                                                                  .icon
-                                                                          ]
-                                                                        : iconMap[
-                                                                              fallbackIconKey
-                                                                          ];
                                                                 const childIsActive =
                                                                     child.current ||
                                                                     pathname ===


### PR DESCRIPTION
## Summary
- add an edit-aware form state for the chart of accounts dialog and refresh local data after updates
- expose a PUT route for updating chart of accounts records in Prisma
- hook the edit action in the table and tidy an unused sidebar variable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12877d6848320b1c662b964e6e444