### PR TITLE
Fix account edit dialog mounting sequence

### DIFF
--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
@@ -60,7 +60,7 @@ export default function ChartOfAccountsPage() {
     }, []);
 
     useEffect(() => {
-        if (!formRef.current) {
+        if (!open || !formRef.current) {
             return;
         }
 
@@ -123,15 +123,9 @@ export default function ChartOfAccountsPage() {
         if (isPostableField instanceof HTMLInputElement) {
             isPostableField.checked = Boolean(selectedAccount.is_postable);
         }
-    }, [selectedAccount]);
+    }, [selectedAccount, open]);
 
     const isLoadingAccounts = !error && accounts.length === 0;
-
-    const handleClose = () => {
-        setOpen(false);
-        setSelectedAccount(null);
-        formRef.current?.reset();
-    };
 
     const handleEdit = (accountId: string) => {
         const accountToEdit = accounts.find((account) => account.id === accountId);
@@ -139,8 +133,8 @@ export default function ChartOfAccountsPage() {
             return;
         }
 
-        setSelectedAccount(accountToEdit);
         setOpen(true);
+        setSelectedAccount(accountToEdit);
     };
 
     const handleSave = async () => {
@@ -321,16 +315,7 @@ export default function ChartOfAccountsPage() {
                                                 <ChartOfAccountsTable
                                                     accounts={accounts}
                                                     onEdit={(account) => {
-                                                        const accountDetails =
-                                                            accounts.find(
-                                                                (item) =>
-                                                                    item.id ===
-                                                                    account.id
-                                                            ) ?? null;
-                                                        setSelectedAccount(
-                                                            accountDetails
-                                                        );
-                                                        setOpen(true);
+                                                        handleEdit(account.id);
                                                     }}
                                                 />
                                             </div>


### PR DESCRIPTION
## Summary
- ensure the account form population only runs once the dialog is open so the fields are mounted
- open the edit dialog before applying the selected account and reuse the handler from the table callback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12d4628b88320bcd8e0bad1bf97a4