### PR TITLE
Fix account update handler to await params context

### DIFF
--- a/app/api/finance-accounting/accounts/[id]/route.ts
+++ b/app/api/finance-accounting/accounts/[id]/route.ts
@@ -16,9 +16,9 @@ type NormalBalance = (typeof NORMAL_BALANCES)[number];
 
 export async function PUT(
     req: NextRequest,
-    { params }: { params: { id: string } }
+    context: { params: Promise<{ id: string }> }
 ) {
-    const accountId = params.id;
+    const { id: accountId } = await context.params;
 
     if (!accountId || typeof accountId !== "string") {
         return NextResponse.json({ error: "Invalid account id" }, { status: 400 });


### PR DESCRIPTION
## Summary
- update the finance accounting account PUT handler to receive the context params promise
- await the params promise before using the account id to maintain existing update logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d133d6c9188320bb98121631901af7