### PR TITLE
Add auto clear effect for save status

### DIFF
--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
@@ -53,6 +53,20 @@ export default function ChartOfAccountsPage() {
     const formRef = useRef<HTMLFormElement>(null);
 
     useEffect(() => {
+        if (!saveStatus) {
+            return;
+        }
+
+        const timeoutId = setTimeout(() => {
+            setSaveStatus(null);
+        }, 3000);
+
+        return () => {
+            clearTimeout(timeoutId);
+        };
+    }, [saveStatus]);
+
+    useEffect(() => {
         const fetchAccounts = async () => {
             try {
                 const res = await fetch("/api/finance-accounting/accounts");


### PR DESCRIPTION
## Summary
- add an effect to automatically reset the chart of accounts save status three seconds after it becomes truthy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d140ea6bec8320bb223cf0f7cdfa4e