### PR TITLE
feat: add journal entries list view

### DIFF
--- a/app/modules/finance-accounting/general-ledger/journal-entries/JournalEntriesTable.tsx
+++ b/app/modules/finance-accounting/general-ledger/journal-entries/JournalEntriesTable.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+export type JournalEntry = {
+    id: string;
+    entryNumber: string;
+    date: string;
+    description: string;
+    amount: number;
+    status: "Draft" | "Posted" | "Reversed";
+    createdBy: string;
+    lastUpdated: string;
+};
+
+type SortKey = "entryNumber" | "date" | "status" | "amount";
+type SortDirection = "asc" | "desc";
+
+type SortConfig = {
+    key: SortKey;
+    direction: SortDirection;
+};
+
+const directionLabels: Record<SortDirection, string> = {
+    asc: "ascending",
+    desc: "descending",
+};
+
+const getSortDescription = (sortConfig: SortConfig, column: SortKey) => {
+    if (sortConfig.key === column) {
+        return `currently sorted ${directionLabels[sortConfig.direction]}`;
+    }
+
+    return "currently unsorted";
+};
+
+function getAriaSort(
+    sortConfig: SortConfig,
+    column: SortKey
+): "ascending" | "descending" | "none" {
+    if (sortConfig.key !== column) {
+        return "none";
+    }
+
+    return sortConfig.direction === "asc" ? "ascending" : "descending";
+}
+
+const SortIndicator = ({
+    active,
+    direction,
+}: {
+    active: boolean;
+    direction: SortDirection;
+}) => (
+    <span aria-hidden="true" className="text-xs">
+        {active ? (direction === "asc" ? "▲" : "▼") : "↕"}
+    </span>
+);
+
+const formatCurrency = (value: number) => {
+    return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 2,
+    }).format(value);
+};
+
+const formatDate = (value: string) => {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return date.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+    });
+};
+
+const getStatusStyles = (status: JournalEntry["status"]) => {
+    switch (status) {
+        case "Posted":
+            return "bg-green-50 text-green-700 ring-green-600/20";
+        case "Draft":
+            return "bg-yellow-50 text-yellow-800 ring-yellow-600/20";
+        case "Reversed":
+            return "bg-red-50 text-red-700 ring-red-600/10";
+        default:
+            return "bg-gray-50 text-gray-700 ring-gray-600/10";
+    }
+};
+
+const compareValues = (
+    a: JournalEntry,
+    b: JournalEntry,
+    sortConfig: SortConfig
+) => {
+    const multiplier = sortConfig.direction === "asc" ? 1 : -1;
+
+    if (sortConfig.key === "date") {
+        const dateA = new Date(a.date).getTime();
+        const dateB = new Date(b.date).getTime();
+        return (dateA - dateB) * multiplier;
+    }
+
+    if (sortConfig.key === "amount") {
+        return (a.amount - b.amount) * multiplier;
+    }
+
+    const valueA = a[sortConfig.key];
+    const valueB = b[sortConfig.key];
+
+    const stringA = valueA == null ? "" : String(valueA);
+    const stringB = valueB == null ? "" : String(valueB);
+
+    return stringA.localeCompare(stringB, undefined, {
+        sensitivity: "base",
+    }) * multiplier;
+};
+
+type JournalEntriesTableProps = {
+    entries: JournalEntry[];
+};
+
+export default function JournalEntriesTable({
+    entries,
+}: JournalEntriesTableProps) {
+    const [sortConfig, setSortConfig] = useState<SortConfig>({
+        key: "date",
+        direction: "desc",
+    });
+
+    const sortedEntries = useMemo(() => {
+        const sorted = [...entries];
+
+        sorted.sort((first, second) => compareValues(first, second, sortConfig));
+
+        return sorted;
+    }, [entries, sortConfig]);
+
+    const handleSort = (key: SortKey) => {
+        setSortConfig((current) => {
+            if (current.key === key) {
+                return {
+                    key,
+                    direction: current.direction === "asc" ? "desc" : "asc",
+                };
+            }
+
+            return {
+                key,
+                direction: "asc",
+            };
+        });
+    };
+
+    return (
+        <div className="flex h-full max-h-[calc(85vh-8rem)] flex-col">
+            <div className="flex-1 overflow-auto">
+                <table className="relative min-w-full divide-y divide-gray-300">
+                    <thead className="sticky top-0 z-10 bg-gray-50">
+                        <tr>
+                            <th
+                                scope="col"
+                                className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                                aria-sort={getAriaSort(sortConfig, "entryNumber")}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => handleSort("entryNumber")}
+                                    className="flex items-center gap-1 text-left font-semibold text-gray-900 focus:outline-none focus-visible:underline"
+                                >
+                                    <span>Entry #</span>
+                                    <SortIndicator
+                                        active={sortConfig.key === "entryNumber"}
+                                        direction={sortConfig.direction}
+                                    />
+                                    <span className="sr-only">
+                                        Sort by entry number, {" "}
+                                        {getSortDescription(sortConfig, "entryNumber")}
+                                    </span>
+                                </button>
+                            </th>
+                            <th
+                                scope="col"
+                                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                                aria-sort={getAriaSort(sortConfig, "date")}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => handleSort("date")}
+                                    className="flex items-center gap-1 text-left font-semibold text-gray-900 focus:outline-none focus-visible:underline"
+                                >
+                                    <span>Date</span>
+                                    <SortIndicator
+                                        active={sortConfig.key === "date"}
+                                        direction={sortConfig.direction}
+                                    />
+                                    <span className="sr-only">
+                                        Sort by date, {" "}
+                                        {getSortDescription(sortConfig, "date")}
+                                    </span>
+                                </button>
+                            </th>
+                            <th
+                                scope="col"
+                                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                            >
+                                Description
+                            </th>
+                            <th
+                                scope="col"
+                                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                                aria-sort={getAriaSort(sortConfig, "amount")}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => handleSort("amount")}
+                                    className="flex items-center gap-1 text-left font-semibold text-gray-900 focus:outline-none focus-visible:underline"
+                                >
+                                    <span>Total Amount</span>
+                                    <SortIndicator
+                                        active={sortConfig.key === "amount"}
+                                        direction={sortConfig.direction}
+                                    />
+                                    <span className="sr-only">
+                                        Sort by amount, {" "}
+                                        {getSortDescription(sortConfig, "amount")}
+                                    </span>
+                                </button>
+                            </th>
+                            <th
+                                scope="col"
+                                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                                aria-sort={getAriaSort(sortConfig, "status")}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => handleSort("status")}
+                                    className="flex items-center gap-1 text-left font-semibold text-gray-900 focus:outline-none focus-visible:underline"
+                                >
+                                    <span>Status</span>
+                                    <SortIndicator
+                                        active={sortConfig.key === "status"}
+                                        direction={sortConfig.direction}
+                                    />
+                                    <span className="sr-only">
+                                        Sort by status, {" "}
+                                        {getSortDescription(sortConfig, "status")}
+                                    </span>
+                                </button>
+                            </th>
+                            <th
+                                scope="col"
+                                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                            >
+                                Created By
+                            </th>
+                            <th
+                                scope="col"
+                                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                            >
+                                Last Updated
+                            </th>
+                            <th
+                                scope="col"
+                                className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                            >
+                                Action
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 bg-white">
+                        {sortedEntries.length === 0 ? (
+                            <tr>
+                                <td
+                                    className="px-3 py-6 text-center text-sm text-gray-500"
+                                    colSpan={8}
+                                >
+                                    No journal entries found.
+                                </td>
+                            </tr>
+                        ) : (
+                            sortedEntries.map((entry) => (
+                                <tr key={entry.id}>
+                                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                                        {entry.entryNumber}
+                                    </td>
+                                    <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                                        {formatDate(entry.date)}
+                                    </td>
+                                    <td className="px-3 py-4 text-sm text-gray-900">
+                                        <p className="font-medium text-gray-900">
+                                            {entry.description}
+                                        </p>
+                                    </td>
+                                    <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                                        {formatCurrency(entry.amount)}
+                                    </td>
+                                    <td className="whitespace-nowrap px-3 py-4 text-sm">
+                                        <span
+                                            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${getStatusStyles(entry.status)}`}
+                                        >
+                                            {entry.status}
+                                        </span>
+                                    </td>
+                                    <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                                        {entry.createdBy}
+                                    </td>
+                                    <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                                        {formatDate(entry.lastUpdated)}
+                                    </td>
+                                    <td className="whitespace-nowrap px-3 py-4 text-sm">
+                                        <button
+                                            type="button"
+                                            className="inline-flex items-center rounded-md px-2.5 py-1.5 text-sm font-medium text-indigo-600 hover:bg-indigo-50 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                                        >
+                                            View
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/app/modules/finance-accounting/general-ledger/journal-entries/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/journal-entries/page.tsx
@@ -1,6 +1,14 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { MagnifyingGlassIcon, FunnelIcon } from "@heroicons/react/24/outline";
+import { PlusIcon } from "@heroicons/react/20/solid";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import PageHeader from "@/components/layout/PageHeader";
 import { RedirectToSignIn, SignedIn, SignedOut } from "@clerk/nextjs";
+import JournalEntriesTable, {
+    JournalEntry,
+} from "./JournalEntriesTable";
 
 const items = [
     { name: "Home", href: "/modules/finance-accounting" },
@@ -14,13 +22,196 @@ const items = [
     },
 ];
 
+const sampleEntries: JournalEntry[] = [
+    {
+        id: "je-2024-001",
+        entryNumber: "JE-2024-001",
+        date: "2024-01-05",
+        description: "January rent accrual",
+        amount: 4500,
+        status: "Posted",
+        createdBy: "Alex Lopez",
+        lastUpdated: "2024-01-07",
+    },
+    {
+        id: "je-2024-002",
+        entryNumber: "JE-2024-002",
+        date: "2024-01-09",
+        description: "Office supplies purchase",
+        amount: 320.75,
+        status: "Posted",
+        createdBy: "Priya Patel",
+        lastUpdated: "2024-01-10",
+    },
+    {
+        id: "je-2024-003",
+        entryNumber: "JE-2024-003",
+        date: "2024-01-12",
+        description: "Payroll adjustment",
+        amount: 1895.25,
+        status: "Draft",
+        createdBy: "Samuel Green",
+        lastUpdated: "2024-01-12",
+    },
+    {
+        id: "je-2024-004",
+        entryNumber: "JE-2024-004",
+        date: "2024-01-20",
+        description: "Revenue recognition - subscription",
+        amount: 8250,
+        status: "Posted",
+        createdBy: "Alex Lopez",
+        lastUpdated: "2024-01-21",
+    },
+    {
+        id: "je-2024-005",
+        entryNumber: "JE-2024-005",
+        date: "2024-01-22",
+        description: "Foreign currency revaluation",
+        amount: 670.1,
+        status: "Draft",
+        createdBy: "Priya Patel",
+        lastUpdated: "2024-01-23",
+    },
+    {
+        id: "je-2024-006",
+        entryNumber: "JE-2024-006",
+        date: "2024-01-24",
+        description: "Customer refund write-off",
+        amount: 210,
+        status: "Reversed",
+        createdBy: "Samuel Green",
+        lastUpdated: "2024-01-26",
+    },
+];
+
+type StatusFilter = "all" | JournalEntry["status"];
+
+const statusOptions: Array<{ label: string; value: StatusFilter }> = [
+    { label: "All statuses", value: "all" },
+    { label: "Draft", value: "Draft" },
+    { label: "Posted", value: "Posted" },
+    { label: "Reversed", value: "Reversed" },
+];
+
 export default function JournalEntriesPage() {
+    const [entries] = useState<JournalEntry[]>(sampleEntries);
+    const [searchQuery, setSearchQuery] = useState("");
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+
+    const filteredEntries = useMemo(() => {
+        const normalizedQuery = searchQuery.trim().toLowerCase();
+
+        return entries.filter((entry) => {
+            const matchesQuery =
+                normalizedQuery.length === 0 ||
+                entry.entryNumber.toLowerCase().includes(normalizedQuery) ||
+                entry.description.toLowerCase().includes(normalizedQuery) ||
+                entry.createdBy.toLowerCase().includes(normalizedQuery);
+
+            const matchesStatus =
+                statusFilter === "all" || entry.status === statusFilter;
+
+            return matchesQuery && matchesStatus;
+        });
+    }, [entries, searchQuery, statusFilter]);
+
     return (
         <>
             <SignedIn>
-                <div className="p-5">
+                <div className="flex min-h-screen flex-col p-5">
                     <Breadcrumb items={items} />
-                    <PageHeader title="Journal Entries" />
+                    <PageHeader
+                        title="Journal Entries"
+                        description="Review, search, and monitor journal entries posted to the general ledger."
+                    />
+
+                    <div className="mt-5 flex flex-wrap items-center gap-4">
+                        <div className="flex w-full flex-1 flex-wrap items-center gap-3 sm:flex-nowrap">
+                            <div className="flex min-w-0 flex-1">
+                                <div className="-mr-px grid grow grid-cols-1 focus-within:relative">
+                                    <input
+                                        id="journal-entry-search"
+                                        name="journal-entry-search"
+                                        type="text"
+                                        placeholder="Search by entry number, description, or preparer"
+                                        value={searchQuery}
+                                        onChange={(event) => {
+                                            setSearchQuery(event.target.value);
+                                        }}
+                                        className="col-start-1 row-start-1 block w-full rounded-l-md bg-white py-1.5 pl-10 pr-3 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
+                                    />
+                                    <MagnifyingGlassIcon
+                                        aria-hidden="true"
+                                        className="pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-gray-400 sm:size-4"
+                                    />
+                                </div>
+                                <button
+                                    type="button"
+                                    className="flex shrink-0 items-center gap-x-1.5 rounded-r-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 hover:bg-gray-50 focus:relative focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600"
+                                >
+                                    <MagnifyingGlassIcon
+                                        aria-hidden="true"
+                                        className="-ml-0.5 size-4 text-gray-400"
+                                    />
+                                    Search
+                                </button>
+                            </div>
+                            <div className="flex items-center gap-2 sm:ml-4">
+                                <label
+                                    htmlFor="status-filter"
+                                    className="inline-flex items-center gap-1 text-sm font-medium text-gray-700"
+                                >
+                                    <FunnelIcon aria-hidden="true" className="size-4 text-gray-400" />
+                                    Status
+                                </label>
+                                <select
+                                    id="status-filter"
+                                    name="status-filter"
+                                    value={statusFilter}
+                                    onChange={(event) => {
+                                        setStatusFilter(event.target.value as StatusFilter);
+                                    }}
+                                    className="rounded-md border-0 bg-white py-1.5 pl-3 pr-8 text-sm text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600"
+                                >
+                                    {statusOptions.map((option) => (
+                                        <option key={option.value} value={option.value}>
+                                            {option.label}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+                        </div>
+                        <button
+                            type="button"
+                            className="inline-flex items-center gap-2 rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        >
+                            <PlusIcon aria-hidden="true" className="size-5" />
+                            New entry
+                        </button>
+                    </div>
+
+                    <div className="mt-4 text-sm text-gray-500">
+                        Showing {filteredEntries.length} of {entries.length} journal entries
+                    </div>
+
+                    <div className="mt-8 flex flex-1 min-h-0 flex-col">
+                        <div className="-mx-4 -my-2 flex-1 min-h-0 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                            <div className="flex h-full min-w-full flex-col py-2 align-middle sm:px-6 lg:px-8">
+                                <div className="flex flex-1 min-h-0 flex-col overflow-hidden shadow outline-1 outline-black/5 sm:rounded-lg">
+                                    {filteredEntries.length === 0 ? (
+                                        <div className="p-4 text-sm text-gray-500">
+                                            No journal entries match your filters.
+                                        </div>
+                                    ) : (
+                                        <div className="flex-1 min-h-0 overflow-y-auto">
+                                            <JournalEntriesTable entries={filteredEntries} />
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </SignedIn>
             <SignedOut>


### PR DESCRIPTION
## Summary
- add a sortable journal entries table component
- build the journal entries page with search, filtering, and list view similar to chart of accounts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ed033ec48320bae2fde590862a6c