### PR TITLE
Add journal entry creation modal

### DIFF
--- a/app/modules/finance-accounting/general-ledger/journal-entries/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/journal-entries/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { MagnifyingGlassIcon, FunnelIcon } from "@heroicons/react/24/outline";
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+import {
+    MagnifyingGlassIcon,
+    FunnelIcon,
+    XMarkIcon,
+} from "@heroicons/react/24/outline";
 import { PlusIcon } from "@heroicons/react/20/solid";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
 import Breadcrumb from "@/components/layout/Breadcrumb";
 import PageHeader from "@/components/layout/PageHeader";
 import { RedirectToSignIn, SignedIn, SignedOut } from "@clerk/nextjs";
@@ -92,10 +97,211 @@ const statusOptions: Array<{ label: string; value: StatusFilter }> = [
     { label: "Reversed", value: "Reversed" },
 ];
 
+type JournalLineForm = {
+    account: string;
+    debit: string;
+    credit: string;
+    memo: string;
+};
+
+type JournalEntryForm = {
+    ledger: string;
+    period: string;
+    entryDate: string;
+    postingDate: string;
+    currency: string;
+    status: JournalEntry["status"];
+    reference: string;
+    memo: string;
+    lines: JournalLineForm[];
+};
+
+type JournalLineError = {
+    account?: string;
+    debit?: string;
+    credit?: string;
+    amount?: string;
+};
+
+type JournalEntryErrors = {
+    ledger?: string;
+    period?: string;
+    entryDate?: string;
+    postingDate?: string;
+    currency?: string;
+    status?: string;
+    reference?: string;
+    memo?: string;
+    form?: string;
+    lines: JournalLineError[];
+};
+
+const createEmptyLine = (): JournalLineForm => ({
+    account: "",
+    debit: "",
+    credit: "",
+    memo: "",
+});
+
+const createDefaultEntryForm = (): JournalEntryForm => ({
+    ledger: "",
+    period: "",
+    entryDate: "",
+    postingDate: "",
+    currency: "USD",
+    status: "Draft",
+    reference: "",
+    memo: "",
+    lines: [createEmptyLine()],
+});
+
+const createDefaultErrors = (lineCount: number): JournalEntryErrors => ({
+    lines: Array.from({ length: lineCount }, () => ({} as JournalLineError)),
+});
+
+const validateEntryForm = (
+    form: JournalEntryForm
+): {
+    errors: JournalEntryErrors;
+    totalDebit: number;
+    totalCredit: number;
+    isValid: boolean;
+} => {
+    const errors: JournalEntryErrors = {
+        ...createDefaultErrors(form.lines.length),
+    };
+
+    if (!form.ledger.trim()) {
+        errors.ledger = "Ledger is required.";
+    }
+
+    if (!form.period.trim()) {
+        errors.period = "Period is required.";
+    }
+
+    if (!form.entryDate.trim()) {
+        errors.entryDate = "Entry date is required.";
+    }
+
+    if (!form.postingDate.trim()) {
+        errors.postingDate = "Posting date is required.";
+    }
+
+    if (!form.currency.trim()) {
+        errors.currency = "Currency is required.";
+    }
+
+    if (!form.status) {
+        errors.status = "Status is required.";
+    }
+
+    if (!form.reference.trim()) {
+        errors.reference = "Reference is required.";
+    }
+
+    let totalDebit = 0;
+    let totalCredit = 0;
+    let hasAmount = false;
+
+    form.lines.forEach((line, index) => {
+        const lineErrors: JournalLineError = {};
+        if (!line.account.trim()) {
+            lineErrors.account = "Account is required.";
+        }
+
+        const debitValue = line.debit.trim() === "" ? 0 : Number(line.debit);
+        const creditValue = line.credit.trim() === "" ? 0 : Number(line.credit);
+
+        if (line.debit.trim() !== "" && Number.isNaN(debitValue)) {
+            lineErrors.debit = "Enter a valid number.";
+        }
+
+        if (line.credit.trim() !== "" && Number.isNaN(creditValue)) {
+            lineErrors.credit = "Enter a valid number.";
+        }
+
+        if (
+            !lineErrors.debit &&
+            !lineErrors.credit &&
+            line.debit.trim() !== "" &&
+            line.credit.trim() !== ""
+        ) {
+            lineErrors.amount = "Use either debit or credit, not both.";
+        }
+
+        if (
+            !lineErrors.debit &&
+            !lineErrors.credit &&
+            debitValue <= 0 &&
+            creditValue <= 0
+        ) {
+            lineErrors.amount = "Enter a debit or credit amount.";
+        }
+
+        if (!lineErrors.debit && !lineErrors.credit && !lineErrors.amount) {
+            hasAmount = true;
+            totalDebit += debitValue;
+            totalCredit += creditValue;
+        }
+
+        errors.lines[index] = lineErrors;
+    });
+
+    if (!hasAmount) {
+        errors.form = "Add at least one journal line with an amount.";
+    } else if (Math.abs(totalDebit - totalCredit) > 0.01) {
+        errors.form = "Total debits must equal total credits.";
+    }
+
+    const hasFieldErrors = Object.entries(errors).some(([key, value]) => {
+        if (key === "lines" || key === "form") {
+            return false;
+        }
+
+        return Boolean(value);
+    });
+
+    const hasLineErrors = errors.lines.some(
+        (lineError) => Object.keys(lineError).length > 0
+    );
+
+    const hasErrors = Boolean(errors.form) || hasFieldErrors || hasLineErrors;
+
+    return {
+        errors,
+        totalDebit,
+        totalCredit,
+        isValid: !hasErrors,
+    };
+};
+
 export default function JournalEntriesPage() {
-    const [entries] = useState<JournalEntry[]>(sampleEntries);
+    const [entries, setEntries] = useState<JournalEntry[]>(sampleEntries);
     const [searchQuery, setSearchQuery] = useState("");
     const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [entryForm, setEntryForm] = useState<JournalEntryForm>(
+        createDefaultEntryForm
+    );
+    const [formErrors, setFormErrors] = useState<JournalEntryErrors>(
+        createDefaultErrors(1)
+    );
+
+    const resetFormState = () => {
+        const defaultForm = createDefaultEntryForm();
+        setEntryForm(defaultForm);
+        setFormErrors(createDefaultErrors(defaultForm.lines.length));
+    };
+
+    const openModal = () => {
+        resetFormState();
+        setIsModalOpen(true);
+    };
+
+    const closeModal = () => {
+        setIsModalOpen(false);
+        resetFormState();
+    };
 
     const filteredEntries = useMemo(() => {
         const normalizedQuery = searchQuery.trim().toLowerCase();
@@ -113,6 +319,147 @@ export default function JournalEntriesPage() {
             return matchesQuery && matchesStatus;
         });
     }, [entries, searchQuery, statusFilter]);
+
+    const handleEntryFieldChange = (
+        field: keyof Omit<JournalEntryForm, "lines">
+    ) =>
+        (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+            const value = event.target.value;
+            setEntryForm((current) => ({
+                ...current,
+                [field]: value,
+            }));
+            setFormErrors((current) => ({
+                ...current,
+                [field]: undefined,
+                form: undefined,
+            }));
+        };
+
+    const handleLineChange = <Field extends keyof JournalLineForm>(
+        index: number,
+        field: Field,
+        value: JournalLineForm[Field]
+    ) => {
+        setEntryForm((current) => {
+            const updatedLines = [...current.lines];
+            updatedLines[index] = {
+                ...updatedLines[index],
+                [field]: value,
+            };
+
+            return {
+                ...current,
+                lines: updatedLines,
+            };
+        });
+
+        setFormErrors((current) => {
+            const updatedLines = [...current.lines];
+            const existingLineErrors = updatedLines[index] ?? {};
+            const updatedLineErrors: JournalLineError = {
+                ...existingLineErrors,
+                amount: undefined,
+            };
+
+            if (field === "account" || field === "debit" || field === "credit") {
+                updatedLineErrors[field] = undefined;
+            }
+
+            updatedLines[index] = updatedLineErrors;
+
+            return {
+                ...current,
+                lines: updatedLines,
+                form: undefined,
+            };
+        });
+    };
+
+    const addJournalLine = () => {
+        setEntryForm((current) => ({
+            ...current,
+            lines: [...current.lines, createEmptyLine()],
+        }));
+        setFormErrors((current) => ({
+            ...current,
+            lines: [...current.lines, {}],
+            form: undefined,
+        }));
+    };
+
+    const removeJournalLine = (index: number) => {
+        setEntryForm((current) => {
+            if (current.lines.length === 1) {
+                return current;
+            }
+
+            const updatedLines = current.lines.filter((_, idx) => idx !== index);
+
+            return {
+                ...current,
+                lines: updatedLines,
+            };
+        });
+
+        setFormErrors((current) => {
+            if (current.lines.length === 1) {
+                return current;
+            }
+
+            const updatedLines = current.lines.filter((_, idx) => idx !== index);
+
+            return {
+                ...current,
+                lines: updatedLines,
+                form: undefined,
+            };
+        });
+    };
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const validation = validateEntryForm(entryForm);
+        setFormErrors(validation.errors);
+
+        if (!validation.isValid) {
+            return;
+        }
+
+        const entryNumber = entryForm.reference.trim().toUpperCase();
+        const memo = entryForm.memo.trim();
+        const description = memo || entryForm.reference.trim() || "New journal entry";
+        const today = new Date();
+        const formattedToday = today.toISOString().slice(0, 10);
+        const totalAmount = Number(validation.totalDebit.toFixed(2));
+
+        const newEntry: JournalEntry = {
+            id: `je-${Date.now()}`,
+            entryNumber: entryNumber || `JE-${today.getFullYear()}-${Date.now()}`,
+            date: entryForm.entryDate,
+            description,
+            amount: totalAmount,
+            status: entryForm.status,
+            createdBy: "Current User",
+            lastUpdated: entryForm.postingDate || formattedToday,
+        };
+
+        setEntries((current) => [newEntry, ...current]);
+        closeModal();
+    };
+
+    const currencyOptions = ["USD", "EUR", "GBP", "JPY"];
+    const ledgerOptions = [
+        { label: "General Ledger", value: "general" },
+        { label: "Sales Ledger", value: "sales" },
+        { label: "Purchases Ledger", value: "purchases" },
+    ];
+    const periodOptions = [
+        { label: "January 2024", value: "2024-01" },
+        { label: "February 2024", value: "2024-02" },
+        { label: "March 2024", value: "2024-03" },
+    ];
 
     return (
         <>
@@ -188,6 +535,7 @@ export default function JournalEntriesPage() {
                         <button
                             type="button"
                             className="inline-flex items-center gap-2 rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            onClick={openModal}
                         >
                             <PlusIcon aria-hidden="true" className="size-5" />
                             New Entry
@@ -219,6 +567,420 @@ export default function JournalEntriesPage() {
                             </div>
                         </div>
                     </div>
+                    <Dialog
+                        open={isModalOpen}
+                        onClose={closeModal}
+                        className="relative z-10"
+                    >
+                        <div className="fixed inset-0 bg-gray-500/75" aria-hidden="true" />
+                        <div className="fixed inset-0 z-10 overflow-y-auto">
+                            <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-6">
+                                <DialogPanel className="relative w-full max-w-4xl transform overflow-hidden rounded-lg bg-white p-6 text-left shadow-xl transition-all">
+                                    <div className="flex items-start justify-between gap-4">
+                                        <DialogTitle className="text-base font-semibold text-gray-900">
+                                            New Journal Entry
+                                        </DialogTitle>
+                                        <button
+                                            type="button"
+                                            onClick={closeModal}
+                                            className="rounded-md p-1 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                        >
+                                            <span className="sr-only">Close</span>
+                                            <XMarkIcon aria-hidden="true" className="size-5" />
+                                        </button>
+                                    </div>
+                                    <form
+                                        className="mt-6 space-y-6"
+                                        onSubmit={handleSubmit}
+                                    >
+                                        {formErrors.form ? (
+                                            <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+                                                {formErrors.form}
+                                            </div>
+                                        ) : null}
+                                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                                            <div>
+                                                <label
+                                                    htmlFor="ledger"
+                                                    className="block text-sm font-medium text-gray-700"
+                                                >
+                                                    Ledger
+                                                </label>
+                                                <select
+                                                    id="ledger"
+                                                    name="ledger"
+                                                    value={entryForm.ledger}
+                                                    onChange={handleEntryFieldChange("ledger")}
+                                                    className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                >
+                                                    <option value="">Select a ledger</option>
+                                                    {ledgerOptions.map((option) => (
+                                                        <option
+                                                            key={option.value}
+                                                            value={option.value}
+                                                        >
+                                                            {option.label}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                                {formErrors.ledger ? (
+                                                    <p className="mt-1 text-sm text-red-600">
+                                                        {formErrors.ledger}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                            <div>
+                                                <label
+                                                    htmlFor="period"
+                                                    className="block text-sm font-medium text-gray-700"
+                                                >
+                                                    Period
+                                                </label>
+                                                <select
+                                                    id="period"
+                                                    name="period"
+                                                    value={entryForm.period}
+                                                    onChange={handleEntryFieldChange("period")}
+                                                    className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                >
+                                                    <option value="">Select a period</option>
+                                                    {periodOptions.map((option) => (
+                                                        <option
+                                                            key={option.value}
+                                                            value={option.value}
+                                                        >
+                                                            {option.label}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                                {formErrors.period ? (
+                                                    <p className="mt-1 text-sm text-red-600">
+                                                        {formErrors.period}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                            <div>
+                                                <label
+                                                    htmlFor="entryDate"
+                                                    className="block text-sm font-medium text-gray-700"
+                                                >
+                                                    Entry Date
+                                                </label>
+                                                <input
+                                                    type="date"
+                                                    id="entryDate"
+                                                    name="entryDate"
+                                                    value={entryForm.entryDate}
+                                                    onChange={handleEntryFieldChange("entryDate")}
+                                                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                />
+                                                {formErrors.entryDate ? (
+                                                    <p className="mt-1 text-sm text-red-600">
+                                                        {formErrors.entryDate}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                            <div>
+                                                <label
+                                                    htmlFor="postingDate"
+                                                    className="block text-sm font-medium text-gray-700"
+                                                >
+                                                    Posting Date
+                                                </label>
+                                                <input
+                                                    type="date"
+                                                    id="postingDate"
+                                                    name="postingDate"
+                                                    value={entryForm.postingDate}
+                                                    onChange={handleEntryFieldChange("postingDate")}
+                                                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                />
+                                                {formErrors.postingDate ? (
+                                                    <p className="mt-1 text-sm text-red-600">
+                                                        {formErrors.postingDate}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                            <div>
+                                                <label
+                                                    htmlFor="currency"
+                                                    className="block text-sm font-medium text-gray-700"
+                                                >
+                                                    Currency
+                                                </label>
+                                                <select
+                                                    id="currency"
+                                                    name="currency"
+                                                    value={entryForm.currency}
+                                                    onChange={handleEntryFieldChange("currency")}
+                                                    className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                >
+                                                    <option value="">Select a currency</option>
+                                                    {currencyOptions.map((option) => (
+                                                        <option key={option} value={option}>
+                                                            {option}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                                {formErrors.currency ? (
+                                                    <p className="mt-1 text-sm text-red-600">
+                                                        {formErrors.currency}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                            <div>
+                                                <label
+                                                    htmlFor="status"
+                                                    className="block text-sm font-medium text-gray-700"
+                                                >
+                                                    Status
+                                                </label>
+                                                <select
+                                                    id="status"
+                                                    name="status"
+                                                    value={entryForm.status}
+                                                    onChange={handleEntryFieldChange("status")}
+                                                    className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                >
+                                                    <option value="">Select a status</option>
+                                                    {statusOptions
+                                                        .filter((option) => option.value !== "all")
+                                                        .map((option) => (
+                                                            <option
+                                                                key={option.value}
+                                                                value={option.value}
+                                                            >
+                                                                {option.label}
+                                                            </option>
+                                                        ))}
+                                                </select>
+                                                {formErrors.status ? (
+                                                    <p className="mt-1 text-sm text-red-600">
+                                                        {formErrors.status}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                            <div className="sm:col-span-2">
+                                                <label
+                                                    htmlFor="reference"
+                                                    className="block text-sm font-medium text-gray-700"
+                                                >
+                                                    Reference
+                                                </label>
+                                                <input
+                                                    type="text"
+                                                    id="reference"
+                                                    name="reference"
+                                                    value={entryForm.reference}
+                                                    onChange={handleEntryFieldChange("reference")}
+                                                    className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                    placeholder="Enter reference or entry number"
+                                                />
+                                                {formErrors.reference ? (
+                                                    <p className="mt-1 text-sm text-red-600">
+                                                        {formErrors.reference}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                            <div className="sm:col-span-2">
+                                                <label
+                                                    htmlFor="memo"
+                                                    className="block text-sm font-medium text-gray-700"
+                                                >
+                                                    Memo
+                                                </label>
+                                                <textarea
+                                                    id="memo"
+                                                    name="memo"
+                                                    value={entryForm.memo}
+                                                    onChange={handleEntryFieldChange("memo")}
+                                                    className="mt-1 min-h-24 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                    placeholder="Describe the purpose of the journal entry"
+                                                />
+                                                {formErrors.memo ? (
+                                                    <p className="mt-1 text-sm text-red-600">
+                                                        {formErrors.memo}
+                                                    </p>
+                                                ) : null}
+                                            </div>
+                                        </div>
+                                        <div className="space-y-4">
+                                            <div className="flex items-center justify-between">
+                                                <h3 className="text-sm font-semibold text-gray-900">
+                                                    Journal Lines
+                                                </h3>
+                                                <button
+                                                    type="button"
+                                                    onClick={addJournalLine}
+                                                    className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                                >
+                                                    Add line
+                                                </button>
+                                            </div>
+                                            <div className="space-y-3">
+                                                {entryForm.lines.map((line, index) => {
+                                                    const lineErrors =
+                                                        formErrors.lines[index] || {};
+
+                                                    return (
+                                                        <div
+                                                            key={`journal-line-${index}`}
+                                                            className="rounded-lg border border-gray-200 p-4"
+                                                        >
+                                                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                                                                <div className="lg:col-span-1">
+                                                                    <label
+                                                                        htmlFor={`line-account-${index}`}
+                                                                        className="block text-sm font-medium text-gray-700"
+                                                                    >
+                                                                        Account
+                                                                    </label>
+                                                                    <input
+                                                                        type="text"
+                                                                        id={`line-account-${index}`}
+                                                                        name={`line-account-${index}`}
+                                                                        value={line.account}
+                                                                        onChange={(event) =>
+                                                                            handleLineChange(
+                                                                                index,
+                                                                                "account",
+                                                                                event.target.value
+                                                                            )
+                                                                        }
+                                                                        className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                                        placeholder="Account name or number"
+                                                                    />
+                                                                    {lineErrors.account ? (
+                                                                        <p className="mt-1 text-sm text-red-600">
+                                                                            {lineErrors.account}
+                                                                        </p>
+                                                                    ) : null}
+                                                                </div>
+                                                                <div>
+                                                                    <label
+                                                                        htmlFor={`line-debit-${index}`}
+                                                                        className="block text-sm font-medium text-gray-700"
+                                                                    >
+                                                                        Debit
+                                                                    </label>
+                                                                    <input
+                                                                        type="number"
+                                                                        id={`line-debit-${index}`}
+                                                                        name={`line-debit-${index}`}
+                                                                        min="0"
+                                                                        step="0.01"
+                                                                        value={line.debit}
+                                                                        onChange={(event) =>
+                                                                            handleLineChange(
+                                                                                index,
+                                                                                "debit",
+                                                                                event.target.value
+                                                                            )
+                                                                        }
+                                                                        className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                                    />
+                                                                    {lineErrors.debit ? (
+                                                                        <p className="mt-1 text-sm text-red-600">
+                                                                            {lineErrors.debit}
+                                                                        </p>
+                                                                    ) : null}
+                                                                </div>
+                                                                <div>
+                                                                    <label
+                                                                        htmlFor={`line-credit-${index}`}
+                                                                        className="block text-sm font-medium text-gray-700"
+                                                                    >
+                                                                        Credit
+                                                                    </label>
+                                                                    <input
+                                                                        type="number"
+                                                                        id={`line-credit-${index}`}
+                                                                        name={`line-credit-${index}`}
+                                                                        min="0"
+                                                                        step="0.01"
+                                                                        value={line.credit}
+                                                                        onChange={(event) =>
+                                                                            handleLineChange(
+                                                                                index,
+                                                                                "credit",
+                                                                                event.target.value
+                                                                            )
+                                                                        }
+                                                                        className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                                    />
+                                                                    {lineErrors.credit ? (
+                                                                        <p className="mt-1 text-sm text-red-600">
+                                                                            {lineErrors.credit}
+                                                                        </p>
+                                                                    ) : null}
+                                                                </div>
+                                                                <div className="lg:col-span-1">
+                                                                    <label
+                                                                        htmlFor={`line-memo-${index}`}
+                                                                        className="block text-sm font-medium text-gray-700"
+                                                                    >
+                                                                        Line Memo
+                                                                    </label>
+                                                                    <input
+                                                                        type="text"
+                                                                        id={`line-memo-${index}`}
+                                                                        name={`line-memo-${index}`}
+                                                                        value={line.memo}
+                                                                        onChange={(event) =>
+                                                                            handleLineChange(
+                                                                                index,
+                                                                                "memo",
+                                                                                event.target.value
+                                                                            )
+                                                                        }
+                                                                        className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                                                        placeholder="Optional memo"
+                                                                    />
+                                                                </div>
+                                                            </div>
+                                                            {lineErrors.amount ? (
+                                                                <p className="mt-3 text-sm text-red-600">
+                                                                    {lineErrors.amount}
+                                                                </p>
+                                                            ) : null}
+                                                            {entryForm.lines.length > 1 ? (
+                                                                <div className="mt-4 flex justify-end">
+                                                                    <button
+                                                                        type="button"
+                                                                        onClick={() =>
+                                                                            removeJournalLine(index)
+                                                                        }
+                                                                        className="text-sm font-medium text-red-600 hover:text-red-500"
+                                                                    >
+                                                                        Remove line
+                                                                    </button>
+                                                                </div>
+                                                            ) : null}
+                                                        </div>
+                                                    );
+                                                })}
+                                            </div>
+                                        </div>
+                                        <div className="flex items-center justify-end gap-3 pt-4">
+                                            <button
+                                                type="button"
+                                                onClick={closeModal}
+                                                className="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                            >
+                                                Cancel
+                                            </button>
+                                            <button
+                                                type="submit"
+                                                className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                            >
+                                                Save Entry
+                                            </button>
+                                        </div>
+                                    </form>
+                                </DialogPanel>
+                            </div>
+                        </div>
+                    </Dialog>
                 </div>
             </SignedIn>
             <SignedOut>


### PR DESCRIPTION
## Summary
- add a headless-ui modal and form to capture new journal entry details and line items
- validate journal entry input, balance debits and credits, and append new entries to the table state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d68026972c8320864d7b092b4c5657