### PR TITLE
Add memo field to journal line form

### DIFF
--- a/app/modules/finance-accounting/general-ledger/journal-entries/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/journal-entries/page.tsx
@@ -100,6 +100,7 @@ const statusOptions: Array<{ label: string; value: StatusFilter }> = [
 type JournalLineForm = {
     account: string;
     description: string;
+    memo: string;
     debit: string;
     credit: string;
     costCenter: string;
@@ -137,6 +138,7 @@ type JournalEntryErrors = {
 const createEmptyLine = (): JournalLineForm => ({
     account: "",
     description: "",
+    memo: "",
     debit: "",
     credit: "",
     costCenter: "",


### PR DESCRIPTION
## Summary
- add a memo field to each journal line and initialize it in the default line factory

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6906177a883209b4612086051f6d2