### PR TITLE
Adjust DataListView layout handling

### DIFF
--- a/app/modules/finance-accounting/settings/fiscal-year-periods/page.tsx
+++ b/app/modules/finance-accounting/settings/fiscal-year-periods/page.tsx
@@ -1,9 +1,55 @@
+"use client";
+
+import DataListView, { DataListColumn } from "@/components/shared/DataListView";
+
+type FiscalYearPeriod = {
+    id: number;
+    name: string;
+    startDate: string;
+    endDate: string;
+};
+
+const columns: DataListColumn<FiscalYearPeriod>[] = [
+    { id: "name", header: "Period", field: "name" },
+    { id: "startDate", header: "Start Date", field: "startDate" },
+    { id: "endDate", header: "End Date", field: "endDate" },
+];
+
+const data: FiscalYearPeriod[] = [];
+
 export default function FiscalYearPeriodsPage() {
+    const handleAdd = () => {
+        console.log("Add fiscal year period");
+    };
+
+    const handleEdit = (item: FiscalYearPeriod) => {
+        console.log("Edit fiscal year period", item.id);
+    };
+
+    const handleDelete = (item: FiscalYearPeriod) => {
+        console.log("Delete fiscal year period", item.id);
+    };
+
     return (
-        <>
-            <h1>Fiscal Year Periods Settings</h1>
-            <p>Manage your fiscal year periods here.</p>
-            {/* TODO: Add fiscal year periods table and actions */}
-        </>
+        <div className="flex h-screen flex-col p-6">
+            <div className="shrink-0">
+                <h1 className="text-2xl font-semibold text-gray-900">
+                    Fiscal Year Periods Settings
+                </h1>
+                <p className="mt-2 text-sm text-gray-600">
+                    Manage your fiscal year periods here.
+                </p>
+            </div>
+            <div className="mt-6 flex-1 overflow-hidden">
+                <DataListView
+                    columns={columns}
+                    data={data}
+                    onAdd={handleAdd}
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                    searchPlaceholder="Search fiscal year periods"
+                />
+            </div>
+        </div>
     );
 }

--- a/components/shared/DataListView.tsx
+++ b/components/shared/DataListView.tsx
@@ -181,7 +181,7 @@ export default function DataListView<T>({
     };
 
     return (
-        <div className="flex h-full flex-col">
+        <div className="flex h-full min-h-0 max-h-screen flex-col overflow-hidden">
             <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="relative w-full sm:max-w-xs">
                     <input
@@ -218,7 +218,7 @@ export default function DataListView<T>({
                     Add
                 </button>
             </div>
-            <div className="flex-1 overflow-x-auto">
+            <div className="flex-1 min-h-0 overflow-x-auto overflow-y-auto">
                 <table className="min-w-full divide-y divide-gray-300">
                     <thead className="bg-gray-50">
                         <tr>


### PR DESCRIPTION
## Summary
- constrain DataListView to the viewport height and allow internal vertical scrolling
- wrap the fiscal year periods settings page in a full-height flex layout and render the shared DataListView component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d76d4fa2c48320b4a863d770bc81e8