### PR TITLE
Add fiscal period editing to fiscal year settings drawer

### DIFF
--- a/app/modules/finance-accounting/settings/fiscal-year-periods/page.tsx
+++ b/app/modules/finance-accounting/settings/fiscal-year-periods/page.tsx
@@ -48,9 +48,31 @@ type FiscalYearRecord = {
     ledger?: LedgerOption | null;
 };
 
+type FiscalYearPeriodRecord = {
+    id: string;
+    period_number: number | null;
+    start_date: string | null;
+    end_date: string | null;
+    status: FiscalYearStatus | null;
+};
+
 type FormValues = {
     ledgerId: string;
     year: string;
+    startDate: string;
+    endDate: string;
+    status: FiscalYearStatus;
+};
+
+type PeriodFieldKey = "periodNumber" | "startDate" | "endDate" | "status";
+
+type PeriodTouchedState = Record<PeriodFieldKey, boolean>;
+
+type PeriodValidationErrors = Partial<Record<PeriodFieldKey, string>>;
+
+type PeriodFormValue = {
+    id?: string;
+    periodNumber: string;
     startDate: string;
     endDate: string;
     status: FiscalYearStatus;
@@ -78,6 +100,33 @@ type StatusMessage = {
     type: "success" | "error";
     message: string;
 };
+
+function createEmptyPeriodValue(): PeriodFormValue {
+    return {
+        periodNumber: "",
+        startDate: "",
+        endDate: "",
+        status: "OPEN",
+    };
+}
+
+function createEmptyPeriodTouched(): PeriodTouchedState {
+    return {
+        periodNumber: false,
+        startDate: false,
+        endDate: false,
+        status: false,
+    };
+}
+
+function createFullPeriodTouched(): PeriodTouchedState {
+    return {
+        periodNumber: true,
+        startDate: true,
+        endDate: true,
+        status: true,
+    };
+}
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
     dateStyle: "medium",
@@ -153,6 +202,75 @@ function validateForm(values: FormValues): {
     };
 }
 
+function validatePeriod(period: PeriodFormValue): {
+    errors: PeriodValidationErrors;
+    isValid: boolean;
+} {
+    const errors: PeriodValidationErrors = {};
+
+    const periodNumber = period.periodNumber.trim();
+    if (!periodNumber) {
+        errors.periodNumber = "Period number is required.";
+    } else if (!/^\d+$/.test(periodNumber)) {
+        errors.periodNumber = "Period number must be a whole number.";
+    }
+
+    if (!period.startDate) {
+        errors.startDate = "Start date is required.";
+    }
+
+    if (!period.endDate) {
+        errors.endDate = "End date is required.";
+    }
+
+    if (period.startDate && period.endDate) {
+        const start = new Date(`${period.startDate}T00:00:00.000Z`).getTime();
+        const end = new Date(`${period.endDate}T00:00:00.000Z`).getTime();
+        if (Number.isNaN(start) || Number.isNaN(end)) {
+            errors.startDate = errors.startDate ?? "Dates must be valid.";
+            errors.endDate = errors.endDate ?? "Dates must be valid.";
+        } else if (end < start) {
+            errors.endDate = "End date cannot be earlier than start date.";
+        }
+    }
+
+    if (!period.status) {
+        errors.status = "Status is required.";
+    }
+
+    return { errors, isValid: Object.keys(errors).length === 0 };
+}
+
+function validatePeriodsList(periods: PeriodFormValue[]): {
+    errors: PeriodValidationErrors[];
+    isValid: boolean;
+} {
+    const errors = periods.map((period) => validatePeriod(period).errors);
+    const isValid = errors.every((item) => Object.keys(item).length === 0);
+
+    return { errors, isValid };
+}
+
+function calculatePeriodErrorsForTouched(
+    periodValues: PeriodFormValue[],
+    touchedList: PeriodTouchedState[]
+) {
+    return periodValues.map((period, index) => {
+        const touched = touchedList[index];
+        if (!touched) {
+            return {} as PeriodValidationErrors;
+        }
+
+        const { errors } = validatePeriod(period);
+
+        return Object.fromEntries(
+            Object.entries(errors).filter(([key]) =>
+                touched[key as PeriodFieldKey]
+            )
+        ) as PeriodValidationErrors;
+    });
+}
+
 function buildStatusLabel(status: string) {
     const normalized = status.toUpperCase();
     return normalized.charAt(0) + normalized.slice(1).toLowerCase();
@@ -170,6 +288,10 @@ export default function FiscalYearPeriodsPage() {
     const [touchedFields, setTouchedFields] =
         useState<Record<keyof FormValues, boolean>>(defaultTouchedFields);
     const [formErrors, setFormErrors] = useState<ValidationErrors>({});
+    const [periods, setPeriods] = useState<PeriodFormValue[]>([]);
+    const [, setPeriodTouched] = useState<PeriodTouchedState[]>([]);
+    const [periodErrors, setPeriodErrors] = useState<PeriodValidationErrors[]>([]);
+    const [isLoadingPeriods, setIsLoadingPeriods] = useState(false);
     const [statusMessage, setStatusMessage] = useState<StatusMessage | null>(
         null
     );
@@ -302,24 +424,97 @@ export default function FiscalYearPeriodsPage() {
             return;
         }
 
-        if (selectedFiscalYear) {
-            setFormValues({
-                ledgerId: selectedFiscalYear.ledger_id ?? "",
-                year: selectedFiscalYear.year
-                    ? String(selectedFiscalYear.year)
-                    : "",
-                startDate: toDateInputValue(selectedFiscalYear.start_date),
-                endDate: toDateInputValue(selectedFiscalYear.end_date),
-                status:
-                    (selectedFiscalYear.status?.toUpperCase() as FiscalYearStatus) ??
-                    "OPEN",
-            });
-        } else {
-            setFormValues(defaultFormValues);
-        }
+        let isActive = true;
 
-        setTouchedFields({ ...defaultTouchedFields });
-        setFormErrors({});
+        const initializeDrawer = async () => {
+            if (selectedFiscalYear) {
+                setFormValues({
+                    ledgerId: selectedFiscalYear.ledger_id ?? "",
+                    year: selectedFiscalYear.year
+                        ? String(selectedFiscalYear.year)
+                        : "",
+                    startDate: toDateInputValue(selectedFiscalYear.start_date),
+                    endDate: toDateInputValue(selectedFiscalYear.end_date),
+                    status:
+                        (selectedFiscalYear.status?.toUpperCase() as FiscalYearStatus) ??
+                        "OPEN",
+                });
+            } else {
+                setFormValues(defaultFormValues);
+            }
+
+            setTouchedFields({ ...defaultTouchedFields });
+            setFormErrors({});
+
+            if (!selectedFiscalYear) {
+                if (!isActive) {
+                    return;
+                }
+                setPeriods([]);
+                setPeriodTouched([]);
+                setPeriodErrors([]);
+                setIsLoadingPeriods(false);
+                return;
+            }
+
+            setIsLoadingPeriods(true);
+
+            try {
+                const response = await fetch(
+                    `/api/finance-accounting/fiscal-years/${selectedFiscalYear.id}?includePeriods=true`
+                );
+
+                if (!response.ok) {
+                    throw new Error("Failed to load fiscal year periods.");
+                }
+
+                const data = (await response.json()) as FiscalYearRecord & {
+                    periods?: FiscalYearPeriodRecord[];
+                };
+
+                if (!isActive) {
+                    return;
+                }
+
+                const derivedPeriods = (data.periods ?? []).map((period) => ({
+                    id: period.id,
+                    periodNumber:
+                        period.period_number !== null && period.period_number !== undefined
+                            ? String(period.period_number)
+                            : "",
+                    startDate: toDateInputValue(period.start_date),
+                    endDate: toDateInputValue(period.end_date),
+                    status:
+                        (period.status?.toUpperCase() as FiscalYearStatus) ?? "OPEN",
+                } satisfies PeriodFormValue));
+
+                setPeriods(derivedPeriods);
+                setPeriodTouched(derivedPeriods.map(() => createEmptyPeriodTouched()));
+                setPeriodErrors(derivedPeriods.map(() => ({})));
+            } catch (error) {
+                console.error(error);
+                if (!isActive) {
+                    return;
+                }
+                setPeriods([]);
+                setPeriodTouched([]);
+                setPeriodErrors([]);
+                setStatusMessage({
+                    type: "error",
+                    message: "Unable to load fiscal year periods.",
+                });
+            } finally {
+                if (isActive) {
+                    setIsLoadingPeriods(false);
+                }
+            }
+        };
+
+        void initializeDrawer();
+
+        return () => {
+            isActive = false;
+        };
     }, [isDrawerOpen, selectedFiscalYear]);
 
     useEffect(() => {
@@ -345,6 +540,13 @@ export default function FiscalYearPeriodsPage() {
                 )
             ) as ValidationErrors;
             setFormErrors(filteredErrors);
+        },
+        []
+    );
+
+    const applyPeriodValidation = useCallback(
+        (values: PeriodFormValue[], touched: PeriodTouchedState[]) => {
+            setPeriodErrors(calculatePeriodErrorsForTouched(values, touched));
         },
         []
     );
@@ -386,6 +588,97 @@ export default function FiscalYearPeriodsPage() {
         [applyValidation, formValues, touchedFields]
     );
 
+    const handlePeriodFieldChange = useCallback(
+        (index: number, field: PeriodFieldKey) =>
+            (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+                const rawValue = event.target.value;
+                const value =
+                    field === "status"
+                        ? ((rawValue.toUpperCase() as FiscalYearStatus) as PeriodFormValue[typeof field])
+                        : (rawValue as PeriodFormValue[typeof field]);
+
+                setPeriods((previous) => {
+                    const updated = previous.map((period, periodIndex) =>
+                        periodIndex === index
+                            ? {
+                                  ...period,
+                                  [field]: value,
+                              }
+                            : period
+                    );
+
+                    setPeriodTouched((previousTouched) => {
+                        const nextTouched = [...previousTouched];
+                        while (nextTouched.length <= index) {
+                            nextTouched.push(createEmptyPeriodTouched());
+                        }
+                        const currentTouched = nextTouched[index];
+                        nextTouched[index] = {
+                            ...currentTouched,
+                            [field]: true,
+                        };
+                        applyPeriodValidation(updated, nextTouched);
+                        return nextTouched;
+                    });
+
+                    return updated;
+                });
+            },
+        [applyPeriodValidation]
+    );
+
+    const handlePeriodFieldBlur = useCallback(
+        (index: number, field: PeriodFieldKey) => () => {
+            setPeriodTouched((previousTouched) => {
+                const nextTouched = [...previousTouched];
+                while (nextTouched.length <= index) {
+                    nextTouched.push(createEmptyPeriodTouched());
+                }
+
+                const currentTouched = nextTouched[index];
+                if (currentTouched[field]) {
+                    return previousTouched;
+                }
+
+                const updatedTouched = {
+                    ...currentTouched,
+                    [field]: true,
+                };
+
+                nextTouched[index] = updatedTouched;
+                applyPeriodValidation(periods, nextTouched);
+
+                return nextTouched;
+            });
+        },
+        [applyPeriodValidation, periods]
+    );
+
+    const handleAddPeriodLine = useCallback(() => {
+        setPeriods((previous) => {
+            const updated = [...previous, createEmptyPeriodValue()];
+            setPeriodTouched((prevTouched) => [
+                ...prevTouched,
+                createEmptyPeriodTouched(),
+            ]);
+            setPeriodErrors((prevErrors) => [...prevErrors, {}]);
+            return updated;
+        });
+    }, []);
+
+    const handleDeletePeriodLine = useCallback((index: number) => {
+        setPeriods((previous) => {
+            const updated = previous.filter((_, periodIndex) => periodIndex !== index);
+            setPeriodTouched((prevTouched) =>
+                prevTouched.filter((_, touchedIndex) => touchedIndex !== index)
+            );
+            setPeriodErrors((prevErrors) =>
+                prevErrors.filter((_, errorIndex) => errorIndex !== index)
+            );
+            return updated;
+        });
+    }, []);
+
     const handleDrawerClose = useCallback(
         (options?: { preserveStatusMessage?: boolean }) => {
             setIsDrawerOpen(false);
@@ -393,6 +686,10 @@ export default function FiscalYearPeriodsPage() {
             setFormValues(defaultFormValues);
             setTouchedFields({ ...defaultTouchedFields });
             setFormErrors({});
+            setPeriods([]);
+            setPeriodTouched([]);
+            setPeriodErrors([]);
+            setIsLoadingPeriods(false);
             setIsSubmitting(false);
 
             if (!options?.preserveStatusMessage) {
@@ -408,6 +705,8 @@ export default function FiscalYearPeriodsPage() {
             setStatusMessage(null);
 
             const { errors, isValid } = validateForm(formValues);
+            const { errors: periodValidationErrors, isValid: arePeriodsValid } =
+                validatePeriodsList(periods);
 
             if (!isValid) {
                 setTouchedFields({
@@ -418,6 +717,15 @@ export default function FiscalYearPeriodsPage() {
                     status: true,
                 });
                 setFormErrors(errors);
+            }
+
+            if (!arePeriodsValid) {
+                const allTouched = periods.map(() => createFullPeriodTouched());
+                setPeriodTouched(allTouched);
+                setPeriodErrors(periodValidationErrors);
+            }
+
+            if (!isValid || !arePeriodsValid) {
                 setStatusMessage({
                     type: "error",
                     message: "Please correct the errors before saving.",
@@ -433,6 +741,13 @@ export default function FiscalYearPeriodsPage() {
                 start_date: `${formValues.startDate}T00:00:00.000Z`,
                 end_date: `${formValues.endDate}T00:00:00.000Z`,
                 status: formValues.status,
+                periods: periods.map((period) => ({
+                    id: period.id,
+                    period_number: Number.parseInt(period.periodNumber, 10),
+                    start_date: `${period.startDate}T00:00:00.000Z`,
+                    end_date: `${period.endDate}T00:00:00.000Z`,
+                    status: period.status,
+                })),
             };
 
             try {
@@ -484,7 +799,13 @@ export default function FiscalYearPeriodsPage() {
                 setIsSubmitting(false);
             }
         },
-        [formValues, handleDrawerClose, refreshFiscalYears, selectedFiscalYear]
+        [
+            formValues,
+            handleDrawerClose,
+            periods,
+            refreshFiscalYears,
+            selectedFiscalYear,
+        ]
     );
 
     const handleAdd = useCallback(() => {
@@ -563,7 +884,11 @@ export default function FiscalYearPeriodsPage() {
     }, [pendingDelete, refreshFiscalYears, resetDeleteState]);
 
     const hasLedgerOptions = ledgerOptions.length > 0;
-    const isFormValid = validateForm(formValues).isValid;
+    const isFormValid = useMemo(() => {
+        const { isValid: formIsValid } = validateForm(formValues);
+        const { isValid: periodsAreValid } = validatePeriodsList(periods);
+        return formIsValid && periodsAreValid;
+    }, [formValues, periods]);
 
     return (
         <>
@@ -988,6 +1313,259 @@ export default function FiscalYearPeriodsPage() {
                                                                 </p>
                                                             ) : null}
                                                         </div>
+                                                    </div>
+
+                                                    <div className="space-y-4 rounded-md border border-gray-200 p-4">
+                                                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                                            <div>
+                                                                <h3 className="text-sm font-semibold text-gray-900">
+                                                                    Fiscal periods
+                                                                </h3>
+                                                                <p className="text-xs text-gray-500">
+                                                                    Define the individual periods for this fiscal year.
+                                                                </p>
+                                                            </div>
+                                                            <div>
+                                                                <button
+                                                                    type="button"
+                                                                    className="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 transition hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-50"
+                                                                    onClick={handleAddPeriodLine}
+                                                                    disabled={
+                                                                        isSubmitting ||
+                                                                        isLoadingPeriods
+                                                                    }
+                                                                >
+                                                                    Add Line
+                                                                </button>
+                                                            </div>
+                                                        </div>
+
+                                                        {isLoadingPeriods ? (
+                                                            <p className="text-sm text-gray-500">
+                                                                Loading periods...
+                                                            </p>
+                                                        ) : periods.length === 0 ? (
+                                                            <p className="text-sm text-gray-500">
+                                                                No periods added yet.
+                                                            </p>
+                                                        ) : (
+                                                            <div className="overflow-x-auto">
+                                                                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                                                                    <thead className="bg-gray-50">
+                                                                        <tr>
+                                                                            <th
+                                                                                scope="col"
+                                                                                className="px-3 py-2 text-left font-semibold text-gray-900"
+                                                                            >
+                                                                                Period #
+                                                                            </th>
+                                                                            <th
+                                                                                scope="col"
+                                                                                className="px-3 py-2 text-left font-semibold text-gray-900"
+                                                                            >
+                                                                                Start date
+                                                                            </th>
+                                                                            <th
+                                                                                scope="col"
+                                                                                className="px-3 py-2 text-left font-semibold text-gray-900"
+                                                                            >
+                                                                                End date
+                                                                            </th>
+                                                                            <th
+                                                                                scope="col"
+                                                                                className="px-3 py-2 text-left font-semibold text-gray-900"
+                                                                            >
+                                                                                Status
+                                                                            </th>
+                                                                            <th
+                                                                                scope="col"
+                                                                                className="px-3 py-2 text-left font-semibold text-gray-900"
+                                                                            >
+                                                                                Actions
+                                                                            </th>
+                                                                        </tr>
+                                                                    </thead>
+                                                                    <tbody className="divide-y divide-gray-200 bg-white">
+                                                                        {periods.map((period, index) => {
+                                                                            const errorsForRow =
+                                                                                periodErrors[index] ?? {};
+
+                                                                            return (
+                                                                                <tr
+                                                                                    key={
+                                                                                        period.id ??
+                                                                                        `period-${index}`
+                                                                                    }
+                                                                                >
+                                                                                    <td className="px-3 py-2 align-top">
+                                                                                        <div
+                                                                                            className={`rounded-md bg-white pl-3 outline-1 -outline-offset-1 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600 ${
+                                                                                                errorsForRow.periodNumber
+                                                                                                    ? "outline-red-500"
+                                                                                                    : "outline-gray-300"
+                                                                                            }`}
+                                                                                        >
+                                                                                            <input
+                                                                                                type="text"
+                                                                                                inputMode="numeric"
+                                                                                                value={
+                                                                                                    period.periodNumber
+                                                                                                }
+                                                                                                onChange={handlePeriodFieldChange(
+                                                                                                    index,
+                                                                                                    "periodNumber"
+                                                                                                )}
+                                                                                                onBlur={handlePeriodFieldBlur(
+                                                                                                    index,
+                                                                                                    "periodNumber"
+                                                                                                )}
+                                                                                                className="block w-full min-w-0 grow bg-transparent py-2 pl-1 pr-3 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none"
+                                                                                                placeholder="e.g. 1"
+                                                                                            />
+                                                                                        </div>
+                                                                                        {errorsForRow.periodNumber ? (
+                                                                                            <p className="mt-2 text-xs text-red-600" role="alert">
+                                                                                                {
+                                                                                                    errorsForRow.periodNumber
+                                                                                                }
+                                                                                            </p>
+                                                                                        ) : null}
+                                                                                    </td>
+                                                                                    <td className="px-3 py-2 align-top">
+                                                                                        <div
+                                                                                            className={`rounded-md bg-white pl-3 outline-1 -outline-offset-1 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600 ${
+                                                                                                errorsForRow.startDate
+                                                                                                    ? "outline-red-500"
+                                                                                                    : "outline-gray-300"
+                                                                                            }`}
+                                                                                        >
+                                                                                            <input
+                                                                                                type="date"
+                                                                                                value={
+                                                                                                    period.startDate
+                                                                                                }
+                                                                                                onChange={handlePeriodFieldChange(
+                                                                                                    index,
+                                                                                                    "startDate"
+                                                                                                )}
+                                                                                                onBlur={handlePeriodFieldBlur(
+                                                                                                    index,
+                                                                                                    "startDate"
+                                                                                                )}
+                                                                                                className="block w-full min-w-0 grow bg-transparent py-2 pl-1 pr-3 text-sm text-gray-900 focus:outline-none"
+                                                                                            />
+                                                                                        </div>
+                                                                                        {errorsForRow.startDate ? (
+                                                                                            <p className="mt-2 text-xs text-red-600" role="alert">
+                                                                                                {
+                                                                                                    errorsForRow.startDate
+                                                                                                }
+                                                                                            </p>
+                                                                                        ) : null}
+                                                                                    </td>
+                                                                                    <td className="px-3 py-2 align-top">
+                                                                                        <div
+                                                                                            className={`rounded-md bg-white pl-3 outline-1 -outline-offset-1 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600 ${
+                                                                                                errorsForRow.endDate
+                                                                                                    ? "outline-red-500"
+                                                                                                    : "outline-gray-300"
+                                                                                            }`}
+                                                                                        >
+                                                                                            <input
+                                                                                                type="date"
+                                                                                                value={
+                                                                                                    period.endDate
+                                                                                                }
+                                                                                                onChange={handlePeriodFieldChange(
+                                                                                                    index,
+                                                                                                    "endDate"
+                                                                                                )}
+                                                                                                onBlur={handlePeriodFieldBlur(
+                                                                                                    index,
+                                                                                                    "endDate"
+                                                                                                )}
+                                                                                                className="block w-full min-w-0 grow bg-transparent py-2 pl-1 pr-3 text-sm text-gray-900 focus:outline-none"
+                                                                                            />
+                                                                                        </div>
+                                                                                        {errorsForRow.endDate ? (
+                                                                                            <p className="mt-2 text-xs text-red-600" role="alert">
+                                                                                                {
+                                                                                                    errorsForRow.endDate
+                                                                                                }
+                                                                                            </p>
+                                                                                        ) : null}
+                                                                                    </td>
+                                                                                    <td className="px-3 py-2 align-top">
+                                                                                        <div
+                                                                                            className={`rounded-md bg-white outline-1 -outline-offset-1 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-indigo-600 ${
+                                                                                                errorsForRow.status
+                                                                                                    ? "outline-red-500"
+                                                                                                    : "outline-gray-300"
+                                                                                            }`}
+                                                                                        >
+                                                                                            <select
+                                                                                                value={
+                                                                                                    period.status
+                                                                                                }
+                                                                                                onChange={handlePeriodFieldChange(
+                                                                                                    index,
+                                                                                                    "status"
+                                                                                                )}
+                                                                                                onBlur={handlePeriodFieldBlur(
+                                                                                                    index,
+                                                                                                    "status"
+                                                                                                )}
+                                                                                                className="block w-full rounded-md border-0 bg-transparent py-2 pl-3 pr-10 text-sm text-gray-900 focus:outline-none"
+                                                                                            >
+                                                                                                {STATUS_OPTIONS.map(
+                                                                                                    (
+                                                                                                        option
+                                                                                                    ) => (
+                                                                                                        <option
+                                                                                                            key={
+                                                                                                                option
+                                                                                                            }
+                                                                                                            value={
+                                                                                                                option
+                                                                                                            }
+                                                                                                        >
+                                                                                                            {buildStatusLabel(
+                                                                                                                option
+                                                                                                            )}
+                                                                                                        </option>
+                                                                                                    )
+                                                                                                )}
+                                                                                            </select>
+                                                                                        </div>
+                                                                                        {errorsForRow.status ? (
+                                                                                            <p className="mt-2 text-xs text-red-600" role="alert">
+                                                                                                {
+                                                                                                    errorsForRow.status
+                                                                                                }
+                                                                                            </p>
+                                                                                        ) : null}
+                                                                                    </td>
+                                                                                    <td className="px-3 py-2 align-top">
+                                                                                        <button
+                                                                                            type="button"
+                                                                                            className="text-sm font-medium text-red-600 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50"
+                                                                                            onClick={() =>
+                                                                                                handleDeletePeriodLine(
+                                                                                                    index
+                                                                                                )
+                                                                                            }
+                                                                                            disabled={isSubmitting}
+                                                                                        >
+                                                                                            Delete Line
+                                                                                        </button>
+                                                                                    </td>
+                                                                                </tr>
+                                                                            );
+                                                                        })}
+                                                                    </tbody>
+                                                                </table>
+                                                            </div>
+                                                        )}
                                                     </div>
 
                                                     <div className="flex justify-end gap-3 border-t border-gray-200 pt-6">


### PR DESCRIPTION
## Summary
- add period form state and validation utilities for managing fiscal year periods
- fetch fiscal year periods when editing, reset drawer state on close, and validate periods before submit
- render an editable fiscal period table with add/delete controls and include periods in the API payload

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7ece75b808320b6ae08a99eb2efab