### PR TITLE
Fix fiscal year period fetch mapping

### DIFF
--- a/app/modules/finance-accounting/settings/fiscal-year-periods/page.tsx
+++ b/app/modules/finance-accounting/settings/fiscal-year-periods/page.tsx
@@ -48,6 +48,11 @@ type FiscalYearRecord = {
     ledger?: LedgerOption | null;
 };
 
+type FetchedFiscalYearRecord = FiscalYearRecord & {
+    period?: FiscalYearPeriodRecord[];
+    periods?: FiscalYearPeriodRecord[];
+};
+
 type FiscalYearPeriodRecord = {
     id: string;
     period_no: number | null;
@@ -470,15 +475,15 @@ export default function FiscalYearPeriodsPage() {
                     throw new Error("Failed to load fiscal year periods.");
                 }
 
-                const data = (await response.json()) as FiscalYearRecord & {
-                    periods?: FiscalYearPeriodRecord[];
-                };
+                const data = (await response.json()) as FetchedFiscalYearRecord;
 
                 if (!isActive) {
                     return;
                 }
 
-                const derivedPeriods = (data.periods ?? []).map(
+                const periodRecords = data.period ?? data.periods ?? [];
+
+                const derivedPeriods = periodRecords.map(
                     (period) =>
                         ({
                             id: period.id,


### PR DESCRIPTION
## Summary
- update the fiscal year response typing to handle `period` and `periods`
- ensure the drawer initializes periods from the API response array

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7fe6fe3388320b1b25e127f7f0802