### PR TITLE
Align chart of accounts views with finance accounts table

### DIFF
--- a/app/api/finance-accounting/accounts/[id]/route.ts
+++ b/app/api/finance-accounting/accounts/[id]/route.ts
@@ -28,7 +28,7 @@ export async function DELETE(
     }
 
     try {
-        await prisma.account.delete({ where: { id: accountId } });
+        await prisma.accounts.delete({ where: { id: accountId } });
 
         return NextResponse.json(
             { message: "Account deleted successfully" },
@@ -145,7 +145,7 @@ export async function PUT(
                 ? description.trim()
                 : null;
 
-        const updatedAccount = await prisma.account.update({
+        const updatedAccount = await prisma.accounts.update({
             where: { id: accountId },
             data: {
                 ledger_id: ledger_id.trim(),

--- a/app/api/finance-accounting/accounts/route.ts
+++ b/app/api/finance-accounting/accounts/route.ts
@@ -15,7 +15,7 @@ type NormalBalance = (typeof NORMAL_BALANCES)[number];
 
 export async function GET() {
     try {
-        const accounts = await prisma.account.findMany();
+        const accounts = await prisma.accounts.findMany();
         const sortedAccounts = accounts.sort((a, b) =>
             a.code.localeCompare(b.code)
         );
@@ -96,7 +96,7 @@ export async function POST(req: NextRequest) {
                 ? description.trim()
                 : null;
 
-        const newAccount = await prisma.account.create({
+        const newAccount = await prisma.accounts.create({
             data: {
                 ledger_id: ledger_id.trim(),
                 code: code.trim(),

--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/ChartOfAccountsTable.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/ChartOfAccountsTable.tsx
@@ -4,16 +4,18 @@ import { useMemo, useState } from "react";
 // Define the Account type locally if not available from @prisma/client
 export type Account = {
     id: string;
+    ledger_id: string;
     code: string;
     name: string;
+    description: string | null;
+    level: number;
+    parent_id: string | null;
     type: string;
     normal_balance: string;
+    is_postable: boolean | null;
     status: string;
-    ledger_id: string;
-    parent_id: string;
-    level: number;
-    description?: string | null;
-    is_postable?: boolean;
+    created_at?: string | Date;
+    updated_at?: string | Date;
 };
 
 type SortKey = "code" | "name";

--- a/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
+++ b/app/modules/finance-accounting/general-ledger/chart-of-accounts/page.tsx
@@ -179,7 +179,7 @@ export default function ChartOfAccountsPage() {
             try {
                 const res = await fetch("/api/finance-accounting/accounts");
                 if (!res.ok) throw new Error("Network response was not ok");
-                const data = await res.json();
+                const data = (await res.json()) as Account[];
                 setAccounts(data);
             } catch (fetchError) {
                 console.error(fetchError);


### PR DESCRIPTION
## Summary
- update chart of accounts API handlers to use the finance.accounts Prisma model
- sync the chart of accounts UI account typings with the finance schema
- ensure client data fetching casts responses to the updated Account shape

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6904a0c6016c832097a76e9b4ccf96ce